### PR TITLE
chore: encrypt secrets at rest, add community files, update repo references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ""
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What should happen.
+
+## Actual behavior
+
+What actually happens.
+
+## Environment
+
+- macOS version:
+- Vox version:
+- Whisper model:
+- LLM provider: Foundry / Bedrock / None

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+---
+
+## Problem
+
+What problem does this feature solve?
+
+## Proposed solution
+
+How should this work?
+
+## Alternatives considered
+
+Any alternative approaches you've thought of.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+Brief description of the changes.
+
+## Changes
+
+- ...
+
+## Test plan
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes
+- [ ] Manually tested (describe how)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,8 @@ jobs:
           This release always points to the latest version. Current: **${{ steps.version.outputs.tag }}**
 
           ### Download
-          - **DMG**: [Vox-arm64.dmg](https://github.com/rodrigoluizs/vox/releases/download/latest/Vox-arm64.dmg)
-          - **Zip**: [Vox-arm64-mac.zip](https://github.com/rodrigoluizs/vox/releases/download/latest/Vox-arm64-mac.zip)
+          - **DMG**: [Vox-arm64.dmg](https://github.com/app-vox/vox/releases/download/latest/Vox-arm64.dmg)
+          - **Zip**: [Vox-arm64-mac.zip](https://github.com/app-vox/vox/releases/download/latest/Vox-arm64-mac.zip)
           NOTES
           )" \
             out/Vox-arm64.dmg out/Vox-arm64-mac.zip

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the maintainer. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Vox
+
+Thanks for your interest in contributing to Vox! Here's how to get started.
+
+## Development setup
+
+```bash
+git clone https://github.com/app-vox/vox.git
+cd vox
+npm install
+npm run dev
+```
+
+## Before submitting a PR
+
+Run all checks locally:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+```
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+type(scope): description
+```
+
+Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `perf`, `style`
+
+Examples:
+- `feat(audio): add noise gate filter`
+- `fix(shortcuts): prevent double-fire on toggle`
+- `refactor(llm): extract retry logic`
+
+## Pull requests
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feat/my-feature`)
+3. Make your changes
+4. Ensure all checks pass
+5. Open a pull request against `main`
+
+Keep PRs focused — one feature or fix per PR.
+
+## Code style
+
+- TypeScript strict mode
+- Code, comments, and documentation in English
+- No unused imports or variables (enforced by ESLint)
+
+## Reporting bugs
+
+Use the [Bug Report](https://github.com/app-vox/vox/issues/new?template=bug_report.md) issue template.
+
+## Requesting features
+
+Use the [Feature Request](https://github.com/app-vox/vox/issues/new?template=feature_request.md) issue template.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Open-source macOS voice-to-text app with local Whisper transcription and LLM-powered correction.
 
-[![CI](https://github.com/rodrigoluizs/vox/actions/workflows/ci.yml/badge.svg)](https://github.com/rodrigoluizs/vox/actions/workflows/ci.yml)
-[![Release](https://github.com/rodrigoluizs/vox/actions/workflows/release.yml/badge.svg)](https://github.com/rodrigoluizs/vox/actions/workflows/release.yml)
+[![CI](https://github.com/app-vox/vox/actions/workflows/ci.yml/badge.svg)](https://github.com/app-vox/vox/actions/workflows/ci.yml)
+[![Release](https://github.com/app-vox/vox/actions/workflows/release.yml/badge.svg)](https://github.com/app-vox/vox/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## About
@@ -51,7 +51,7 @@ A floating indicator pill shows the current stage (Listening, Transcribing, Corr
 
 ```bash
 brew install sox
-git clone https://github.com/rodrigoluizs/vox.git
+git clone https://github.com/app-vox/vox.git
 cd vox
 npm install
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Vox, please report it responsibly.
+
+**Do not open a public issue.** Instead, email **rodrigoluizscs@gmail.com** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You should receive a response within 72 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Scope
+
+This policy applies to the Vox application code in this repository. Third-party dependencies are covered by their own security policies.
+
+## Sensitive data handling
+
+- API keys and credentials entered in Vox settings are encrypted at rest using the operating system keychain via Electron's `safeStorage` API
+- Audio recordings are processed locally and never stored to disk
+- Only transcribed text (not audio) is sent to the configured LLM provider when enhancement is enabled

--- a/docs/release-workflow-setup.md
+++ b/docs/release-workflow-setup.md
@@ -14,7 +14,7 @@ Open **Keychain Access** on your Mac:
 
 1. In the sidebar, select the **login** keychain
 2. Click the **My Certificates** category
-3. Find **"Developer ID Application: Rodrigo Luiz Dos Santos Costa Silva (7Y57846YR9)"**
+3. Find your **"Developer ID Application: Your Name (TEAM_ID)"** certificate
 4. Right-click it > **Export...**
 5. Choose format **Personal Information Exchange (.p12)**
 6. Set a strong password (you'll need it for the GitHub secret)

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -1,6 +1,7 @@
 import { app, nativeTheme, session } from "electron";
 import * as path from "path";
 import { ConfigManager } from "./config/manager";
+import { createSecretStore } from "./config/secrets";
 import { ModelManager } from "./models/manager";
 import { AudioRecorder } from "./audio/recorder";
 import { transcribe } from "./audio/whisper";
@@ -13,7 +14,7 @@ import { registerIpcHandlers } from "./ipc";
 
 const configDir = path.join(app.getPath("userData"));
 const modelsDir = path.join(configDir, "models");
-const configManager = new ConfigManager(configDir);
+const configManager = new ConfigManager(configDir, createSecretStore());
 const modelManager = new ModelManager(modelsDir);
 
 let pipeline: Pipeline | null = null;

--- a/src/main/config/secrets.ts
+++ b/src/main/config/secrets.ts
@@ -1,0 +1,21 @@
+import { safeStorage } from "electron";
+import type { SecretStore } from "./manager";
+
+const ENCRYPTED_PREFIX = "enc:";
+
+export function createSecretStore(): SecretStore {
+  return {
+    encrypt(plainText: string): string {
+      if (!safeStorage.isEncryptionAvailable()) return plainText;
+      const buffer = safeStorage.encryptString(plainText);
+      return ENCRYPTED_PREFIX + buffer.toString("base64");
+    },
+
+    decrypt(cipherText: string): string {
+      if (!cipherText.startsWith(ENCRYPTED_PREFIX)) return cipherText;
+      if (!safeStorage.isEncryptionAvailable()) return cipherText;
+      const buffer = Buffer.from(cipherText.slice(ENCRYPTED_PREFIX.length), "base64");
+      return safeStorage.decryptString(buffer);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Encrypt API keys and credentials (`apiKey`, `secretAccessKey`, `accessKeyId`) at rest using Electron's `safeStorage` API backed by macOS Keychain
- `SecretStore` is required (not optional) — secrets are always encrypted on macOS
- Transparent migration: existing plaintext configs are decrypted as-is and encrypted on next save
- Generalize `docs/release-workflow-setup.md` — remove personal Developer ID certificate name/Team ID
- Add community files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
- Add GitHub issue templates (bug report, feature request) and PR template
- Update all repository references from `rodrigoluizs/vox` to `app-vox/vox`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 52 tests pass (including 4 new encryption tests)
- [ ] Verify existing config with plaintext keys is migrated on first load+save
- [ ] Verify `config.json` on disk shows `enc:` prefixed values after save