### PR TITLE
chore: add ignore pattern to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/*.provisionprofile
 # Local notes and plans
 open-source-audit.md
 docs/plans/
+**ignore**


### PR DESCRIPTION
## Summary
- Add `**ignore**` glob pattern to `.gitignore`

## Test plan
- [ ] Verify files matching the pattern are excluded from git tracking