### PR TITLE
feat(app): enable Cmd+Tab visibility on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
-        "LSUIElement": true,
+        "LSUIElement": false,
         "NSMicrophoneUsageDescription": "Vox needs microphone access to record your voice for transcription.",
         "NSAccessibilityUsageDescription": "Vox needs accessibility access to paste transcribed text automatically."
       }


### PR DESCRIPTION
## Summary
- Set LSUIElement to false in package.json
- Makes the app visible in Cmd+Tab application switcher on macOS
- Provides a more standard macOS application experience
- Improves app discoverability

## Test plan
- [ ] Build and run app on macOS
- [ ] Press Cmd+Tab and verify Vox appears in the application switcher
- [ ] Verify app icon appears in the Dock
- [ ] Test that app still functions normally with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)