### PR TITLE
feat(ui): add Report Issue link to tray and settings

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -197,4 +197,8 @@ export function registerIpcHandlers(
       return { ok: false, error: err instanceof Error ? err.message : String(err), hasAccessibility };
     }
   });
+
+  ipcMain.handle("shell:open-external", async (_event, url: string) => {
+    await shell.openExternal(url);
+  });
 }

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,4 +1,4 @@
-import { app, Tray, Menu, nativeImage } from "electron";
+import { app, Tray, Menu, nativeImage, shell } from "electron";
 import { getResourcePath } from "./resources";
 
 let tray: Tray | null = null;
@@ -57,6 +57,8 @@ function updateTrayMenu(): void {
   }
 
   menuTemplate.push(
+    { type: "separator" },
+    { label: "Report Issue", click: () => shell.openExternal("https://github.com/app-vox/vox/issues") },
     { type: "separator" },
     { label: "Quit", click: () => app.quit() }
   );

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,9 @@ export interface VoxAPI {
     getSystemDark(): Promise<boolean>;
     onSystemThemeChanged(callback: (isDark: boolean) => void): void;
   };
+  shell: {
+    openExternal(url: string): Promise<void>;
+  };
 }
 
 const voxApi: VoxAPI = {
@@ -110,6 +113,9 @@ const voxApi: VoxAPI = {
     onSystemThemeChanged: (callback) => {
       ipcRenderer.on("theme:system-changed", (_event, isDark: boolean) => callback(isDark));
     },
+  },
+  shell: {
+    openExternal: (url) => ipcRenderer.invoke("shell:open-external", url),
   },
 };
 

--- a/src/renderer/components/appearance/AppearancePanel.module.scss
+++ b/src/renderer/components/appearance/AppearancePanel.module.scss
@@ -70,3 +70,33 @@
   color: var(--color-text-tertiary);
   line-height: 1.4;
 }
+
+.linkButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: var(--color-bg-hover);
+    border-color: var(--color-border-hover);
+  }
+
+  svg:first-child {
+    color: var(--color-text-secondary);
+  }
+
+  svg:last-child {
+    color: var(--color-text-tertiary);
+    width: 12px;
+    height: 12px;
+  }
+}

--- a/src/renderer/components/appearance/AppearancePanel.tsx
+++ b/src/renderer/components/appearance/AppearancePanel.tsx
@@ -69,6 +69,10 @@ export function AppearancePanel() {
     triggerToast();
   };
 
+  const openIssueTracker = () => {
+    window.voxApi.shell.openExternal("https://github.com/app-vox/vox/issues");
+  };
+
   return (
     <>
       <div className={card.card}>
@@ -115,6 +119,28 @@ export function AppearancePanel() {
               </div>
             </div>
           </label>
+        </div>
+      </div>
+
+      <div className={card.card}>
+        <div className={card.header}>
+          <h2>Help & Support</h2>
+          <p className={card.description}>Get help or report issues with Vox.</p>
+        </div>
+        <div className={card.body}>
+          <button onClick={openIssueTracker} className={styles.linkButton}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <span>Report Issue</span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </button>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- Added "Report Issue" option in tray menu (separated section before Quit)
- Added "Help & Support" section in Appearance settings with Report Issue button
- Added shell.openExternal API to preload for opening external links safely
- Both options open GitHub issues page: https://github.com/app-vox/vox/issues

## Changes

### Tray Menu
- New "Report Issue" menu item before Quit
- Separated with dividers for visual clarity
- Opens GitHub issues in default browser

### Settings UI (Appearance Tab)
- New "Help & Support" card at bottom
- "Report Issue" button with icon and external link indicator
- Consistent styling with rest of the UI

### API Addition
- Added `shell.openExternal()` to VoxAPI (preload)
- Added IPC handler `shell:open-external` in main process
- Safely opens URLs in user's default browser

## UI Preview

**Tray Menu:**
```
Show Vox
Start Listening
───────────────
Report Issue
───────────────
Quit
```

**Settings (Appearance Tab):**
New "Help & Support" section with styled button linking to GitHub issues.

## Test Plan
- [x] Click "Report Issue" in tray menu → opens GitHub issues
- [x] Click "Report Issue" in settings → opens GitHub issues
- [x] Verify button styling matches UI design system
- [x] Verify separators in tray menu look clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)