### PR TITLE
fix(memory): prevent EventEmitter leak in download progress listeners

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,7 +41,7 @@ export interface VoxAPI {
     download(size: string): Promise<void>;
     cancelDownload(size: string): Promise<void>;
     delete(size: string): Promise<void>;
-    onDownloadProgress(callback: (progress: DownloadProgress) => void): void;
+    onDownloadProgress(callback: (progress: DownloadProgress) => void): () => void;
   };
   shortcuts: {
     disable(): Promise<void>;
@@ -84,7 +84,9 @@ const voxApi: VoxAPI = {
     cancelDownload: (size) => ipcRenderer.invoke("models:cancel-download", size),
     delete: (size) => ipcRenderer.invoke("models:delete", size),
     onDownloadProgress: (callback) => {
-      ipcRenderer.on("models:download-progress", (_event, progress: DownloadProgress) => callback(progress));
+      const handler = (_event: Electron.IpcRendererEvent, progress: DownloadProgress) => callback(progress);
+      ipcRenderer.on("models:download-progress", handler);
+      return () => ipcRenderer.removeListener("models:download-progress", handler);
     },
   },
   shortcuts: {

--- a/src/renderer/components/whisper/ModelRow.tsx
+++ b/src/renderer/components/whisper/ModelRow.tsx
@@ -28,7 +28,8 @@ export function ModelRow({ model, selected, onSelect }: ModelRowProps) {
         setProgress({ downloaded: p.downloaded, total: p.total });
       }
     };
-    window.voxApi.models.onDownloadProgress(handler);
+    const cleanup = window.voxApi.models.onDownloadProgress(handler);
+    return cleanup;
   }, [model.size]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes the `MaxListenersExceededWarning` that appears when multiple `ModelRow` components register download progress listeners without cleanup.

## Problem

```
(node:63033) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 
11 models:download-progress listeners added to [IpcRenderer]. 
MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
```

**Root cause:** 
- Each `ModelRow` component was calling `onDownloadProgress()` in a `useEffect`
- The listener was never removed when component unmounted or re-rendered
- With 5+ model rows visible, listeners accumulated quickly

## Solution

**Modified `onDownloadProgress` API to return cleanup function:**

```typescript
// Before (no cleanup):
onDownloadProgress: (callback) => {
  ipcRenderer.on("models:download-progress", (_event, progress) => callback(progress));
},

// After (returns cleanup):
onDownloadProgress: (callback) => {
  const handler = (_event, progress) => callback(progress);
  ipcRenderer.on("models:download-progress", handler);
  return () => ipcRenderer.removeListener("models:download-progress", handler);
},
```

**Updated `ModelRow` to use cleanup:**

```typescript
// Before (no cleanup):
useEffect(() => {
  const handler = (p) => { /* ... */ };
  window.voxApi.models.onDownloadProgress(handler);
}, [model.size]);

// After (with cleanup):
useEffect(() => {
  const handler = (p) => { /* ... */ };
  const cleanup = window.voxApi.models.onDownloadProgress(handler);
  return cleanup;
}, [model.size]);
```

## Changes

- `src/preload/index.ts`: Changed `onDownloadProgress` return type to `() => void` and implementation to return cleanup function
- `src/renderer/components/whisper/ModelRow.tsx`: Store cleanup function and return it from useEffect

## Testing

- [x] No more MaxListenersExceededWarning in console
- [x] Download progress still updates correctly
- [x] Multiple ModelRow components can exist simultaneously
- [x] Component unmount properly removes listeners
- [x] No memory leaks

## Impact

- **Before**: Listeners accumulated indefinitely, causing memory leak warnings
- **After**: Listeners are properly cleaned up on component unmount/re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)