### PR TITLE
fix(ui): auto-select model after download, rename tab, add icons

### DIFF
--- a/src/renderer/components/layout/TabNav.module.scss
+++ b/src/renderer/components/layout/TabNav.module.scss
@@ -8,6 +8,9 @@
 
 .tab {
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 12px 16px;
   background: none;
   border: none;
@@ -18,12 +21,27 @@
   transition: color 150ms ease;
   white-space: nowrap;
 
+  svg {
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+    transition: opacity 150ms ease;
+  }
+
   &:hover {
     color: var(--color-text-secondary);
+
+    svg {
+      opacity: 0.85;
+    }
   }
 
   &.active {
     color: var(--color-text-primary);
+
+    svg {
+      opacity: 1;
+    }
 
     &::after {
       content: "";

--- a/src/renderer/components/layout/TabNav.tsx
+++ b/src/renderer/components/layout/TabNav.tsx
@@ -1,12 +1,67 @@
+import type { ReactNode } from "react";
 import { useConfigStore } from "../../stores/config-store";
 import styles from "./TabNav.module.scss";
 
-const TABS = [
-  { id: "whisper", label: "Local Model" },
-  { id: "llm", label: "AI Improvement" },
-  { id: "shortcuts", label: "Shortcuts" },
-  { id: "permissions", label: "Permissions" },
-  { id: "appearance", label: "Appearance" },
+const TABS: { id: string; label: string; icon: ReactNode }[] = [
+  {
+    id: "whisper",
+    label: "Local Model",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+        <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+        <line x1="12" y1="19" x2="12" y2="23" />
+        <line x1="8" y1="23" x2="16" y2="23" />
+      </svg>
+    ),
+  },
+  {
+    id: "llm",
+    label: "AI Improvements",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2L2 7l10 5 10-5-10-5z" />
+        <path d="M2 17l10 5 10-5" />
+        <path d="M2 12l10 5 10-5" />
+      </svg>
+    ),
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M6 8h.01" />
+        <path d="M10 8h.01" />
+        <path d="M14 8h.01" />
+        <path d="M18 8h.01" />
+        <path d="M8 12h.01" />
+        <path d="M12 12h.01" />
+        <path d="M16 12h.01" />
+        <path d="M7 16h10" />
+      </svg>
+    ),
+  },
+  {
+    id: "permissions",
+    label: "Permissions",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+    ),
+  },
+  {
+    id: "appearance",
+    label: "Appearance",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M12 1v6m0 6v6m5.2-17.2l-4.2 4.2m-2 2l-4.2 4.2M23 12h-6m-6 0H1m17.2 5.2l-4.2-4.2m-2-2l-4.2-4.2" />
+      </svg>
+    ),
+  },
 ];
 
 export function TabNav() {
@@ -21,7 +76,8 @@ export function TabNav() {
           onClick={() => setActiveTab(tab.id)}
           className={`${styles.tab} ${activeTab === tab.id ? styles.active : ""}`}
         >
-          {tab.label}
+          {tab.icon}
+          <span>{tab.label}</span>
         </button>
       ))}
     </nav>


### PR DESCRIPTION
## Summary

Three UI improvements:
1. Fixed model not auto-selecting after download
2. Renamed "AI Improvement" to "AI Improvements" (plural)
3. Added icons to all navigation tabs

## Changes

### 1. Auto-select Model After Download

**Problem:** After downloading a model, it was auto-selected in config but the UI didn't update until page refresh.

**Root cause:** 
- IPC handler saved config but didn't notify renderer
- WhisperPanel didn't refresh models list or config after download completed

**Solution:**
- Added download progress listener in WhisperPanel
- When download reaches 100%, refresh both models list and config
- UI now updates immediately showing selected model

### 2. Rename Tab Label

Changed "AI Improvement" → "AI Improvements" (plural) for consistency.

### 3. Add Icons to Navigation Tabs

Added icons to all tabs for better visual hierarchy:
- **Local Model**: Microphone icon (representing voice input)
- **AI Improvements**: Layers icon (representing enhancement processing)
- **Shortcuts**: Keyboard icon (representing keyboard shortcuts)
- **Permissions**: Shield icon (representing security/permissions)
- **Appearance**: Settings/gear icon (representing visual settings)

**Icon styling:**
- Base opacity: 0.7 (inactive)
- Hover opacity: 0.85
- Active opacity: 1.0
- Smooth transitions for all states
- Consistent 16x16px size

## UI Preview

**Before:**
```
Local Model | AI Improvement | Shortcuts | Permissions | Appearance
```

**After:**
```
🎤 Local Model | 📚 AI Improvements | ⌨️ Shortcuts | 🛡️ Permissions | ⚙️ Appearance
```

## Test Plan

- [x] Download a model → automatically selected in UI
- [x] UI refreshes immediately (no page reload needed)
- [x] Tab shows "AI Improvements" (plural)
- [x] All tabs show icons
- [x] Icon opacity changes on hover/active states
- [x] Icons align properly with text
- [x] Active tab indicator still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)