### PR TITLE
fix(llm): improve punctuation detection and remove bullet point formatting

### DIFF
--- a/src/main/pipeline.ts
+++ b/src/main/pipeline.ts
@@ -21,29 +21,6 @@ export interface PipelineDeps {
 }
 
 /**
- * Format enumerated lists with bullet points.
- * Detects numbered lists (1., 2., etc.) and converts to bullet points.
- */
-function formatEnumeratedList(text: string): string {
-  // Match number followed by period/parenthesis/dash at start of line or after newline
-  // Examples: "1. Item", "1) Item", "1 - Item"
-  const numberedListPattern = /(^|[\r\n]+)\s*(\d+)[.)]\s+/g;
-
-  // Count how many numbered items exist
-  const matches = [...text.matchAll(numberedListPattern)];
-  if (matches.length < 2) {
-    return text; // Not a list or only one item
-  }
-
-  // Replace numbered prefixes with bullet points, preserving line breaks
-  const formatted = text.replace(numberedListPattern, (match, lineBreak) => {
-    return `${lineBreak}• `;
-  });
-
-  return formatted;
-}
-
-/**
  * Detect non-speech Whisper output caused by background noise.
  * Whisper hallucinates in two ways with noise:
  * 1. Repetitive characters/tokens (e.g. "ლლლლლლ")
@@ -153,9 +130,6 @@ export class Pipeline {
     if (this.canceled) {
       throw new CanceledError();
     }
-
-    // Format enumerated lists with bullet points
-    finalText = formatEnumeratedList(finalText);
 
     return finalText;
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -39,12 +39,15 @@ export const LLM_SYSTEM_PROMPT = `You are a speech-to-text post-processor. You r
 1. Fix speech recognition errors and typos
 2. Remove ONLY filler words (um, uh, like, you know, etc.) - NOT actual content words
 3. Remove laughter markers and sounds (e.g., "[laughter]", "haha", "hehe", etc.)
-4. Fix grammar and punctuation
+4. Fix grammar and punctuation based on intonation and context
 5. CRITICAL: Preserve ALL words the speaker said, including profanity, slang, and strong language
 6. NEVER censor, remove, or replace profanity or controversial words
 7. NEVER sanitize or "clean up" the user's language choices
-8. If the input contains a question (indicated by rising intonation, question words like "what", "why", "how", "when", "where", "who", or context suggesting inquiry), preserve it as a question with a question mark
-9. Maintain the interrogative nature of questions even when fixing grammar
+8. Detect speaker's intonation and emotion:
+   - Questions (rising intonation, question words) → use question mark (?)
+   - Exclamations (excitement, emphasis, commands) → use exclamation mark (!)
+   - Statements (neutral tone) → use period (.)
+9. Pay attention to emotional cues: loud volume, emphasis, urgency, excitement should get exclamation marks
 10. Do not rephrase, summarize, or add content beyond fixing transcription errors
 11. Do not add greetings, sign-offs, or formatting
 12. Detect the language automatically and respond in the same language


### PR DESCRIPTION
## Summary

Two improvements to LLM text processing:
1. Enhanced punctuation detection to include exclamation marks based on intonation
2. Removed automatic bullet point formatting (addresses Issue #34)

## Changes

### 1. Improved Punctuation Detection

**Before:** Only detected questions (?) based on question words and rising intonation.

**After:** Now detects three types of punctuation based on speaker's intonation:
- **Questions** (rising intonation, question words) → question mark (?)
- **Exclamations** (excitement, emphasis, commands, urgency) → exclamation mark (!)
- **Statements** (neutral tone) → period (.)

**Updated system prompt rules:**
```
8. Detect speaker's intonation and emotion:
   - Questions (rising intonation, question words) → use question mark (?)
   - Exclamations (excitement, emphasis, commands) → use exclamation mark (!)
   - Statements (neutral tone) → use period (.)
9. Pay attention to emotional cues: loud volume, emphasis, urgency, excitement should get exclamation marks
```

**Examples:**
- "stop doing that" → "Stop doing that!"
- "that's amazing" → "That's amazing!"
- "look at this" → "Look at this!"
- "what is that" → "What is that?"
- "the weather is nice" → "The weather is nice."

### 2. Removed Bullet Point Formatting

**Problem:** The `formatEnumeratedList()` function automatically converted numbered lists to bullet points, which wasn't always desired.

**Before:**
```
Input: "1. First item\n2. Second item\n3. Third item"
Output: "• First item\n• Second item\n• Third item"
```

**After:**
```
Input: "1. First item\n2. Second item\n• Third item"
Output: "1. First item\n2. Second item\n• Third item"
```

LLM now preserves whatever list format the user dictated (numbered or bullet points).

**Removed:**
- `formatEnumeratedList()` function (24 lines)
- Call to `formatEnumeratedList()` in pipeline

## Testing

### Test Exclamation Marks
1. Record: "That's incredible"
   - Expected: "That's incredible!"
2. Record: "Stop right there"
   - Expected: "Stop right there!"
3. Record: "Look at this"
   - Expected: "Look at this!"

### Test Question Marks (Still Work)
1. Record: "What time is it"
   - Expected: "What time is it?"

### Test List Formatting
1. Record: "First do this, second do that, third finish up"
   - Expected: Preserves whatever format LLM chooses (not forced to bullets)

## Closes

Partially addresses #34 (removes bullet point auto-formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)