### PR TITLE
feat(llm): add OpenAI and DeepSeek provider support

### DIFF
--- a/src/main/llm/factory.ts
+++ b/src/main/llm/factory.ts
@@ -3,6 +3,7 @@ import { type VoxConfig } from "../../shared/config";
 import { LLM_SYSTEM_PROMPT } from "../../shared/constants";
 import { FoundryProvider } from "./foundry";
 import { BedrockProvider } from "./bedrock";
+import { OpenAICompatibleProvider } from "./openai-compatible";
 import { NoopProvider } from "./noop";
 
 export function createLlmProvider(config: VoxConfig): LlmProvider {
@@ -26,6 +27,15 @@ export function createLlmProvider(config: VoxConfig): LlmProvider {
         accessKeyId: config.llm.accessKeyId,
         secretAccessKey: config.llm.secretAccessKey,
         modelId: config.llm.modelId,
+        customPrompt: prompt,
+      });
+
+    case "openai":
+    case "deepseek":
+      return new OpenAICompatibleProvider({
+        endpoint: config.llm.openaiEndpoint,
+        apiKey: config.llm.openaiApiKey,
+        model: config.llm.openaiModel,
         customPrompt: prompt,
       });
 

--- a/src/main/llm/openai-compatible.ts
+++ b/src/main/llm/openai-compatible.ts
@@ -1,0 +1,57 @@
+import { type LlmProvider } from "./provider";
+
+export interface OpenAICompatibleConfig {
+  endpoint: string;
+  apiKey: string;
+  model: string;
+  customPrompt: string;
+}
+
+interface ChatCompletionResponse {
+  choices: { message: { content: string } }[];
+}
+
+export class OpenAICompatibleProvider implements LlmProvider {
+  private readonly config: OpenAICompatibleConfig;
+
+  constructor(config: OpenAICompatibleConfig) {
+    this.config = config;
+  }
+
+  async correct(rawText: string): Promise<string> {
+    const hasCustom = this.config.customPrompt.includes("ADDITIONAL CUSTOM INSTRUCTIONS");
+    console.log("[OpenAICompatibleProvider] Correcting text, custom prompt:", hasCustom ? "YES" : "NO");
+
+    const base = this.config.endpoint.replace(/\/+$/, "");
+    const url = `${base}/v1/chat/completions`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages: [
+          { role: "system", content: this.config.customPrompt },
+          { role: "user", content: rawText },
+        ],
+        temperature: 0.3,
+        max_tokens: 4096,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`LLM request failed: ${response.status} ${response.statusText} — ${body}`);
+    }
+
+    const data = await response.json() as ChatCompletionResponse;
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error("LLM returned no text content");
+    }
+    return content.trim();
+  }
+}

--- a/src/renderer/components/llm/LlmPanel.tsx
+++ b/src/renderer/components/llm/LlmPanel.tsx
@@ -3,6 +3,7 @@ import { useConfigStore } from "../../stores/config-store";
 import { useDebouncedSave } from "../../hooks/use-debounced-save";
 import { FoundryFields } from "./FoundryFields";
 import { BedrockFields } from "./BedrockFields";
+import { OpenAICompatibleFields } from "./OpenAICompatibleFields";
 import { StatusBox } from "../ui/StatusBox";
 import type { LlmProviderType } from "../../../shared/config";
 import card from "../shared/card.module.scss";
@@ -21,8 +22,18 @@ export function LlmPanel() {
 
   if (!config) return null;
 
+  const providerDefaults: Record<string, { openaiEndpoint: string; openaiModel: string }> = {
+    openai: { openaiEndpoint: "https://api.openai.com", openaiModel: "gpt-4o" },
+    deepseek: { openaiEndpoint: "https://api.deepseek.com", openaiModel: "deepseek-chat" },
+  };
+
   const handleProviderChange = (provider: LlmProviderType) => {
-    updateConfig({ llm: { ...config.llm, provider } });
+    const defaults = providerDefaults[provider];
+    if (defaults) {
+      updateConfig({ llm: { ...config.llm, provider, ...defaults } });
+    } else {
+      updateConfig({ llm: { ...config.llm, provider } });
+    }
     saveConfig(true);
   };
 
@@ -100,10 +111,18 @@ export function LlmPanel() {
                   >
                     <option value="foundry">Microsoft Foundry</option>
                     <option value="bedrock">AWS Bedrock</option>
+                    <option value="openai">OpenAI</option>
+                    <option value="deepseek">DeepSeek</option>
                   </select>
                 </div>
 
-                {config.llm.provider === "bedrock" ? <BedrockFields /> : <FoundryFields />}
+                {(config.llm.provider === "openai" || config.llm.provider === "deepseek") ? (
+                  <OpenAICompatibleFields providerType={config.llm.provider} />
+                ) : config.llm.provider === "bedrock" ? (
+                  <BedrockFields />
+                ) : (
+                  <FoundryFields />
+                )}
 
                 <div className={form.testSection}>
                   <button

--- a/src/renderer/components/llm/OpenAICompatibleFields.tsx
+++ b/src/renderer/components/llm/OpenAICompatibleFields.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useConfigStore } from "../../stores/config-store";
+import { useDebouncedSave } from "../../hooks/use-debounced-save";
+import { SecretInput } from "../ui/SecretInput";
+import form from "../shared/forms.module.scss";
+
+const PROVIDER_DEFAULTS: Record<string, { endpoint: string; model: string }> = {
+  openai: { endpoint: "https://api.openai.com", model: "gpt-4o" },
+  deepseek: { endpoint: "https://api.deepseek.com", model: "deepseek-chat" },
+};
+
+export function OpenAICompatibleFields({ providerType }: { providerType: "openai" | "deepseek" }) {
+  const config = useConfigStore((s) => s.config);
+  const updateConfig = useConfigStore((s) => s.updateConfig);
+  const { debouncedSave, flush } = useDebouncedSave(500, true);
+  const [focusedField, setFocusedField] = useState<{ field: string; value: string } | null>(null);
+
+  if (!config) return null;
+
+  const defaults = PROVIDER_DEFAULTS[providerType];
+
+  const update = (field: string, value: string) => {
+    updateConfig({ llm: { ...config.llm, [field]: value } });
+    debouncedSave();
+  };
+
+  const handleFocus = (field: string, value: string) => {
+    setFocusedField({ field, value });
+  };
+
+  const handleBlur = (field: string, currentValue: string) => {
+    if (focusedField && focusedField.field === field && focusedField.value !== currentValue) {
+      flush();
+    }
+    setFocusedField(null);
+  };
+
+  return (
+    <>
+      <div className={form.field}>
+        <label htmlFor="llm-openai-apikey">API Key</label>
+        <SecretInput
+          id="llm-openai-apikey"
+          value={config.llm.openaiApiKey || ""}
+          onChange={(v) => update("openaiApiKey", v)}
+          onFocus={() => handleFocus("openaiApiKey", config.llm.openaiApiKey || "")}
+          onBlur={() => handleBlur("openaiApiKey", config.llm.openaiApiKey || "")}
+          placeholder="Enter your API key"
+        />
+      </div>
+      <div className={form.field}>
+        <label htmlFor="llm-openai-model">Model</label>
+        <input
+          id="llm-openai-model"
+          type="text"
+          value={config.llm.openaiModel || ""}
+          onChange={(e) => update("openaiModel", e.target.value)}
+          onFocus={(e) => handleFocus("openaiModel", e.target.value)}
+          onBlur={(e) => handleBlur("openaiModel", e.target.value)}
+          placeholder={defaults.model}
+        />
+      </div>
+      <div className={form.field}>
+        <label htmlFor="llm-openai-endpoint">Endpoint</label>
+        <input
+          id="llm-openai-endpoint"
+          type="url"
+          value={config.llm.openaiEndpoint || ""}
+          onChange={(e) => update("openaiEndpoint", e.target.value)}
+          onFocus={(e) => handleFocus("openaiEndpoint", e.target.value)}
+          onBlur={(e) => handleBlur("openaiEndpoint", e.target.value)}
+          placeholder={defaults.endpoint}
+        />
+        <p className={form.hint}>
+          Pre-filled for {providerType === "openai" ? "OpenAI" : "DeepSeek"}. Change only if using a custom endpoint.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,6 +1,6 @@
 export type ThemeMode = "light" | "dark" | "system";
 
-export type LlmProviderType = "foundry" | "bedrock";
+export type LlmProviderType = "foundry" | "bedrock" | "openai" | "deepseek";
 
 export interface LlmConfig {
   provider: LlmProviderType;
@@ -16,6 +16,11 @@ export interface LlmConfig {
   accessKeyId: string;
   secretAccessKey: string;
   modelId: string;
+
+  // OpenAI-compatible fields (OpenAI, DeepSeek)
+  openaiApiKey: string;
+  openaiModel: string;
+  openaiEndpoint: string;
 }
 
 export interface WhisperConfig {
@@ -51,6 +56,9 @@ export function createDefaultConfig(): VoxConfig {
       accessKeyId: "",
       secretAccessKey: "",
       modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      openaiApiKey: "",
+      openaiModel: "gpt-4o",
+      openaiEndpoint: "https://api.openai.com",
     },
     whisper: {
       model: "small",


### PR DESCRIPTION
## Summary
- Add generic `OpenAICompatibleProvider` class that handles any OpenAI Chat Completions-compatible API
- Add OpenAI and DeepSeek as separate provider options in the UI dropdown, each pre-filling endpoint URL and default model
- Extend config schema with `openaiApiKey`, `openaiModel`, and `openaiEndpoint` fields
- Update LLM factory to route both `openai` and `deepseek` providers to the shared implementation

## Test plan
- [x] Select OpenAI provider in dropdown — verify endpoint pre-fills to `https://api.openai.com` and model to `gpt-4o`
- [ ] Select DeepSeek provider in dropdown — verify endpoint pre-fills to `https://api.deepseek.com` and model to `deepseek-chat`
- [x] Enter API key and click "Test Connection" for each provider
- [x] Verify transcription correction works end-to-end with OpenAI/DeepSeek
- [x] Switch between all 4 providers (Foundry, Bedrock, OpenAI, DeepSeek) and verify fields update correctly
- [x] Verify existing Foundry and Bedrock providers are not affected

Closes #10, closes #11