### PR TITLE
feat(deps): add Renovate Bot for automated dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ build/*.provisionprofile
 open-source-audit.md
 docs/plans/
 **ignore**
+
+# Git worktrees
+.worktrees/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,17 @@ Keep PRs focused — one feature or fix per PR.
 - Code, comments, and documentation in English
 - No unused imports or variables (enforced by ESLint)
 
+## Dependency management
+
+[Renovate Bot](https://docs.renovatebot.com/) automatically manages npm dependency updates. It creates pull requests for outdated packages, grouped by category (Electron, React, AWS SDK, etc.).
+
+- **Dependency Dashboard**: A GitHub issue tracks all pending, rate-limited, and ignored updates.
+- **Automerge**: Patch updates and low-risk devDependency changes merge automatically when CI passes.
+- **Native modules** (`whisper-node`, `koffi`, `uiohook-napi`): These are never automerged and include a manual testing checklist — verify audio recording, shortcuts, and builds on both arm64 and x64 Mac.
+- **Major updates**: Always require manual review and are separated into individual PRs.
+
+See `renovate.json` for the full configuration.
+
 ## Reporting bugs
 
 Use the [Bug Report](https://github.com/app-vox/vox/issues/new?template=bug_report.md) issue template.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6364,6 +6364,7 @@
       "integrity": "sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.7.0",
         "builder-util": "26.4.1",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":separateMajorReleases"
+  ],
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security", "priority:high"],
+    "automerge": false
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Automerge patch updates for all packages",
+      "matchUpdateTypes": ["patch", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Automerge minor updates for devDependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Group Electron ecosystem packages",
+      "groupName": "Electron ecosystem",
+      "matchPackageNames": ["electron", "electron-builder", "electron-vite"],
+      "minimumReleaseAge": "7 days",
+      "automerge": false,
+      "labels": ["dependencies", "electron", "needs-testing"]
+    },
+    {
+      "description": "Group AWS SDK packages",
+      "groupName": "AWS SDK",
+      "matchPackagePatterns": ["^@aws-sdk/"]
+    },
+    {
+      "description": "Group React packages",
+      "groupName": "React",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
+    },
+    {
+      "description": "Group build tools",
+      "groupName": "Build tools",
+      "matchPackageNames": [
+        "vite",
+        "vitest",
+        "typescript",
+        "sass",
+        "tailwindcss"
+      ],
+      "matchPackagePatterns": ["^@vitejs/", "^@tailwindcss/"]
+    },
+    {
+      "description": "Group linters and formatters with automerge",
+      "groupName": "Linters and formatters",
+      "matchPackagePatterns": ["^eslint", "^prettier", "^stylelint"],
+      "matchPackageNames": ["typescript-eslint"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Automerge type definitions (excluding React types handled by React group)",
+      "groupName": "Type definitions",
+      "matchPackagePatterns": ["^@types/"],
+      "excludePackageNames": ["@types/react", "@types/react-dom"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Native modules require manual testing on both architectures",
+      "groupName": "Native modules",
+      "matchPackageNames": ["whisper-node", "koffi", "uiohook-napi"],
+      "schedule": ["before 3am on the first day of the month"],
+      "minimumReleaseAge": "7 days",
+      "automerge": false,
+      "labels": ["dependencies", "native-module", "needs-testing"],
+      "prBodyNotes": [
+        "**Native module update — requires manual testing:**",
+        "- [ ] Test on arm64 Mac (Apple Silicon)",
+        "- [ ] Test on x64 Mac (Intel)",
+        "- [ ] Verify audio recording works",
+        "- [ ] Verify shortcuts work",
+        "- [ ] Check DMG build succeeds"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `renovate.json` with complete configuration for automated dependency management
- Group related packages (Electron, React, AWS SDK, build tools, linters, native modules) to reduce PR noise
- Configure automerge for patch updates and low-risk devDependency changes
- Add special handling for native modules with manual testing checklist
- Update `CONTRIBUTING.md` with dependency management documentation

## Configuration highlights

| Feature | Setting |
|---------|---------|
| Semantic commits | `chore(deps): ...` |
| Rate limiting | 5 concurrent PRs, 2/hour |
| Min release age | 3 days |
| Vulnerability alerts | Enabled (OSV + GitHub) |
| Native modules | Monthly, never automerge, testing checklist |
| Electron | 7-day release age, never automerge |
| Linters/types | Automerge enabled |

## Test plan

- [x] `renovate.json` is valid JSON
- [x] All 52 existing tests pass
- [ ] Verify Renovate onboarding PR is created after merge
- [ ] Verify Dependency Dashboard issue is created
- [ ] Monitor first batch of update PRs for correct grouping

Closes #18