### PR TITLE
feat(llm): add LiteLLM provider support

### DIFF
--- a/src/main/llm/factory.ts
+++ b/src/main/llm/factory.ts
@@ -32,6 +32,7 @@ export function createLlmProvider(config: VoxConfig): LlmProvider {
 
     case "openai":
     case "deepseek":
+    case "litellm":
       return new OpenAICompatibleProvider({
         endpoint: config.llm.openaiEndpoint,
         apiKey: config.llm.openaiApiKey,

--- a/src/renderer/components/llm/LiteLLMFields.tsx
+++ b/src/renderer/components/llm/LiteLLMFields.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useConfigStore } from "../../stores/config-store";
+import { useDebouncedSave } from "../../hooks/use-debounced-save";
+import { SecretInput } from "../ui/SecretInput";
+import form from "../shared/forms.module.scss";
+
+const DEFAULTS = {
+  endpoint: "http://localhost:4000",
+  model: "gpt-4o",
+};
+
+export function LiteLLMFields() {
+  const config = useConfigStore((s) => s.config);
+  const updateConfig = useConfigStore((s) => s.updateConfig);
+  const { debouncedSave, flush } = useDebouncedSave(500, true);
+  const [focusedField, setFocusedField] = useState<{ field: string; value: string } | null>(null);
+
+  if (!config) return null;
+
+  const update = (field: string, value: string) => {
+    updateConfig({ llm: { ...config.llm, [field]: value } });
+    debouncedSave();
+  };
+
+  const handleFocus = (field: string, value: string) => {
+    setFocusedField({ field, value });
+  };
+
+  const handleBlur = (field: string, currentValue: string) => {
+    if (focusedField && focusedField.field === field && focusedField.value !== currentValue) {
+      flush();
+    }
+    setFocusedField(null);
+  };
+
+  return (
+    <>
+      <div className={form.field}>
+        <label htmlFor="llm-litellm-endpoint">Endpoint</label>
+        <input
+          id="llm-litellm-endpoint"
+          type="url"
+          value={config.llm.openaiEndpoint || ""}
+          onChange={(e) => update("openaiEndpoint", e.target.value)}
+          onFocus={(e) => handleFocus("openaiEndpoint", e.target.value)}
+          onBlur={(e) => handleBlur("openaiEndpoint", e.target.value)}
+          placeholder={DEFAULTS.endpoint}
+        />
+        <p className={form.hint}>
+          URL of your LiteLLM proxy instance (e.g., http://localhost:4000).
+        </p>
+      </div>
+      <div className={form.field}>
+        <label htmlFor="llm-litellm-apikey">API Key</label>
+        <SecretInput
+          id="llm-litellm-apikey"
+          value={config.llm.openaiApiKey || ""}
+          onChange={(v) => update("openaiApiKey", v)}
+          onFocus={() => handleFocus("openaiApiKey", config.llm.openaiApiKey || "")}
+          onBlur={() => handleBlur("openaiApiKey", config.llm.openaiApiKey || "")}
+          placeholder="Optional — depends on your LiteLLM setup"
+        />
+        <p className={form.hint}>
+          Only required if your LiteLLM proxy is configured with authentication.
+        </p>
+      </div>
+      <div className={form.field}>
+        <label htmlFor="llm-litellm-model">Model</label>
+        <input
+          id="llm-litellm-model"
+          type="text"
+          value={config.llm.openaiModel || ""}
+          onChange={(e) => update("openaiModel", e.target.value)}
+          onFocus={(e) => handleFocus("openaiModel", e.target.value)}
+          onBlur={(e) => handleBlur("openaiModel", e.target.value)}
+          placeholder={DEFAULTS.model}
+        />
+        <p className={form.hint}>
+          LiteLLM uses the format <code>provider/model</code> for provider-specific models:
+          {" "}gpt-4o, azure/gpt-4, bedrock/claude-3, anthropic/claude-3-5-sonnet, cohere/command-r-plus.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/renderer/components/llm/LlmPanel.tsx
+++ b/src/renderer/components/llm/LlmPanel.tsx
@@ -4,6 +4,7 @@ import { useDebouncedSave } from "../../hooks/use-debounced-save";
 import { FoundryFields } from "./FoundryFields";
 import { BedrockFields } from "./BedrockFields";
 import { OpenAICompatibleFields } from "./OpenAICompatibleFields";
+import { LiteLLMFields } from "./LiteLLMFields";
 import { StatusBox } from "../ui/StatusBox";
 import type { LlmProviderType } from "../../../shared/config";
 import card from "../shared/card.module.scss";
@@ -25,6 +26,7 @@ export function LlmPanel() {
   const providerDefaults: Record<string, { openaiEndpoint: string; openaiModel: string }> = {
     openai: { openaiEndpoint: "https://api.openai.com", openaiModel: "gpt-4o" },
     deepseek: { openaiEndpoint: "https://api.deepseek.com", openaiModel: "deepseek-chat" },
+    litellm: { openaiEndpoint: "http://localhost:4000", openaiModel: "gpt-4o" },
   };
 
   const handleProviderChange = (provider: LlmProviderType) => {
@@ -113,10 +115,13 @@ export function LlmPanel() {
                     <option value="bedrock">AWS Bedrock</option>
                     <option value="openai">OpenAI</option>
                     <option value="deepseek">DeepSeek</option>
+                    <option value="litellm">LiteLLM</option>
                   </select>
                 </div>
 
-                {(config.llm.provider === "openai" || config.llm.provider === "deepseek") ? (
+                {config.llm.provider === "litellm" ? (
+                  <LiteLLMFields />
+                ) : (config.llm.provider === "openai" || config.llm.provider === "deepseek") ? (
                   <OpenAICompatibleFields providerType={config.llm.provider} />
                 ) : config.llm.provider === "bedrock" ? (
                   <BedrockFields />

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,6 +1,6 @@
 export type ThemeMode = "light" | "dark" | "system";
 
-export type LlmProviderType = "foundry" | "bedrock" | "openai" | "deepseek";
+export type LlmProviderType = "foundry" | "bedrock" | "openai" | "deepseek" | "litellm";
 
 export interface LlmConfig {
   provider: LlmProviderType;


### PR DESCRIPTION
## Summary
- Add LiteLLM as an LLM provider option, enabling access to 100+ LLM providers through a unified OpenAI-compatible proxy
- Reuse existing `OpenAICompatibleProvider` backend — no new provider class needed
- Create dedicated `LiteLLMFields.tsx` UI component with LiteLLM-specific defaults and hints

### Changes
- `src/shared/config.ts`: Add `"litellm"` to `LlmProviderType` union
- `src/main/llm/factory.ts`: Route `"litellm"` through `OpenAICompatibleProvider`
- `src/renderer/components/llm/LlmPanel.tsx`: Add LiteLLM to provider dropdown with defaults (`http://localhost:4000`, `gpt-4o`)
- `src/renderer/components/llm/LiteLLMFields.tsx`: New UI component with endpoint, optional API key, and model input with `provider/model` naming convention hints

## Test plan
- [x] Select LiteLLM from the provider dropdown — verify fields render correctly
- [x] Verify endpoint defaults to `http://localhost:4000`
- [x] Verify API key field shows "Optional" placeholder
- [x] Verify model field hint shows `provider/model` format examples
- [x] Switch between providers (OpenAI → LiteLLM → DeepSeek) — verify defaults update correctly
- [x] Test Connection with a running LiteLLM proxy
- [x] Verify pipeline processes text correction through LiteLLM

Closes #16