### PR TITLE
fix(ci): remove incompatible TypeScript linters from MegaLinter

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -7,8 +7,6 @@ FILEIO_REPORTER: false
 
 # Linter categories
 ENABLE:
-  - JAVASCRIPT
-  - TYPESCRIPT
   - JSON
   - YAML
   - MARKDOWN
@@ -17,10 +15,6 @@ ENABLE:
 DISABLE:
   - COPYPASTE
   - SPELL
-
-# Use project ESLint config
-JAVASCRIPT_ES_CONFIG_FILE: eslint.config.mjs
-TYPESCRIPT_ES_CONFIG_FILE: eslint.config.mjs
 
 # checkov: skip CKV_GHA_7 (workflow_dispatch inputs are intentional in release.yml)
 REPOSITORY_CHECKOV_ARGUMENTS: --skip-check CKV_GHA_7


### PR DESCRIPTION
## Summary
- Remove `JAVASCRIPT` and `TYPESCRIPT` categories from MegaLinter's `ENABLE` list
- Remove now-unused `JAVASCRIPT_ES_CONFIG_FILE` and `TYPESCRIPT_ES_CONFIG_FILE` settings
- TypeScript linting remains handled by the CI workflow (`npm run lint`)

## Context
MegaLinter's bundled eslint v8.57.1 is incompatible with the project's flat config (`eslint.config.mjs`), causing `--no-eslintrc` errors. Additionally, `ts-standard` fails because it doesn't support the project's multi-tsconfig setup. Both linters are redundant since the CI workflow already runs eslint and typecheck.

This was causing failures on external PRs (e.g. #86).

## Test plan
- [ ] MegaLinter passes without TYPESCRIPT/JAVASCRIPT linter errors
- [ ] CI workflow still runs eslint and typecheck independently