### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rodrigoluizs @guicheffer


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `@rodrigoluizs` and `@guicheffer` as owners for all files
- The ruleset has `require_code_owner_review: true` but without this file the rule had no effect

## Test plan
- [x] Verify CODEOWNERS syntax is valid after merge
- [x] Confirm future PRs require review from a code owner