### PR TITLE
feat(tray): add status info and unify enhancement terminology

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -8,7 +8,7 @@ import { transcribe } from "./audio/whisper";
 import { createLlmProvider } from "./llm/factory";
 import { Pipeline } from "./pipeline";
 import { ShortcutManager } from "./shortcuts/manager";
-import { setupTray, setTrayModelState } from "./tray";
+import { setupTray, setTrayModelState, updateTrayConfig } from "./tray";
 import { openHome } from "./windows/home";
 import { registerIpcHandlers } from "./ipc";
 import { isAccessibilityGranted } from "./input/paster";
@@ -41,6 +41,7 @@ function setupPipeline(): void {
 function reloadConfig(): void {
   setupPipeline();
   shortcutManager?.registerShortcutKeys();
+  updateTrayConfig(configManager.load());
 
   const setupChecker = new SetupChecker(modelManager);
   setTrayModelState(setupChecker.hasAnyModel());
@@ -95,6 +96,7 @@ app.whenReady().then(async () => {
     onCancelListening: () => shortcutManager?.cancelRecording(),
   });
   setTrayModelState(setupChecker.hasAnyModel());
+  updateTrayConfig(configManager.load());
 
   if (!app.isPackaged) {
     openHome(reloadConfig);

--- a/src/main/indicator.ts
+++ b/src/main/indicator.ts
@@ -1,11 +1,11 @@
 import { BrowserWindow, screen } from "electron";
 
-type IndicatorMode = "listening" | "transcribing" | "correcting" | "error" | "canceled";
+type IndicatorMode = "listening" | "transcribing" | "enhancing" | "error" | "canceled";
 
 const LABELS: Record<IndicatorMode, { color: string; text: string; pulse: boolean }> = {
   listening:    { color: "#ff4444", text: "Listening...",    pulse: false },
   transcribing: { color: "#ffaa00", text: "Transcribing...", pulse: true },
-  correcting:   { color: "#44aaff", text: "Correcting...",   pulse: true },
+  enhancing:    { color: "#44aaff", text: "Enhancing...",    pulse: true },
   error:        { color: "#fbbf24", text: "Nothing heard",   pulse: false },
   canceled:     { color: "#fbbf24", text: "Canceled",        pulse: false },
 };

--- a/src/main/llm/bedrock.ts
+++ b/src/main/llm/bedrock.ts
@@ -45,7 +45,7 @@ export class BedrockProvider implements LlmProvider {
 
   async correct(rawText: string): Promise<string> {
     const hasCustom = this.customPrompt.includes("ADDITIONAL CUSTOM INSTRUCTIONS");
-    console.log("[BedrockProvider] Correcting text, custom prompt:", hasCustom ? "YES" : "NO");
+    console.log("[BedrockProvider] Enhancing text, custom prompt:", hasCustom ? "YES" : "NO");
 
     const command = new ConverseCommand({
       modelId: this.modelId,

--- a/src/main/llm/foundry.ts
+++ b/src/main/llm/foundry.ts
@@ -20,7 +20,7 @@ export class FoundryProvider implements LlmProvider {
 
   async correct(rawText: string): Promise<string> {
     const hasCustom = this.config.customPrompt.includes("ADDITIONAL CUSTOM INSTRUCTIONS");
-    console.log("[FoundryProvider] Correcting text, custom prompt:", hasCustom ? "YES" : "NO");
+    console.log("[FoundryProvider] Enhancing text, custom prompt:", hasCustom ? "YES" : "NO");
 
     const base = this.config.endpoint.replace(/\/+$/, "");
     const url = `${base}/v1/messages`;

--- a/src/main/llm/openai-compatible.ts
+++ b/src/main/llm/openai-compatible.ts
@@ -20,7 +20,7 @@ export class OpenAICompatibleProvider implements LlmProvider {
 
   async correct(rawText: string): Promise<string> {
     const hasCustom = this.config.customPrompt.includes("ADDITIONAL CUSTOM INSTRUCTIONS");
-    console.log("[OpenAICompatibleProvider] Correcting text, custom prompt:", hasCustom ? "YES" : "NO");
+    console.log("[OpenAICompatibleProvider] Enhancing text, custom prompt:", hasCustom ? "YES" : "NO");
 
     const base = this.config.endpoint.replace(/\/+$/, "");
     const url = `${base}/v1/chat/completions`;

--- a/src/main/pipeline.ts
+++ b/src/main/pipeline.ts
@@ -4,7 +4,7 @@ import { type RecordingResult } from "./audio/recorder";
 import { type TranscriptionResult } from "./audio/whisper";
 import { existsSync } from "fs";
 
-export type PipelineStage = "transcribing" | "correcting";
+export type PipelineStage = "transcribing" | "enhancing";
 
 export interface PipelineDeps {
   recorder: {
@@ -166,12 +166,12 @@ export class Pipeline {
 
     let finalText: string;
     try {
-      this.deps.onStage?.("correcting");
+      this.deps.onStage?.("enhancing");
       finalText = await this.deps.llmProvider.correct(rawText);
-      console.log("[Vox] LLM corrected text:", finalText);
+      console.log("[Vox] LLM enhanced text:", finalText);
     } catch (err: unknown) {
       // LLM failed — fall back to raw transcription
-      console.log("[Vox] LLM correction failed, using raw transcription:", err instanceof Error ? err.message : err);
+      console.log("[Vox] LLM enhancement failed, using raw transcription:", err instanceof Error ? err.message : err);
       finalText = rawText;
     }
 

--- a/src/main/shortcuts/manager.ts
+++ b/src/main/shortcuts/manager.ts
@@ -174,7 +174,7 @@ export class ShortcutManager {
     }, 1000);
   }
 
-  showIndicator(mode: "listening" | "transcribing" | "correcting" | "error"): void {
+  showIndicator(mode: "listening" | "transcribing" | "enhancing" | "error"): void {
     this.indicator.show(mode);
   }
 

--- a/src/renderer/components/layout/TabNav.tsx
+++ b/src/renderer/components/layout/TabNav.tsx
@@ -6,7 +6,7 @@ import styles from "./TabNav.module.scss";
 const TABS: { id: string; label: string; icon: ReactNode; requiresModel?: boolean }[] = [
   {
     id: "whisper",
-    label: "Local Model",
+    label: "Speech",
     requiresModel: true,
     icon: (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -19,7 +19,7 @@ const TABS: { id: string; label: string; icon: ReactNode; requiresModel?: boolea
   },
   {
     id: "llm",
-    label: "AI Improvements",
+    label: "AI Enhancement",
     icon: (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M12 2L2 7l10 5 10-5-10-5z" />

--- a/src/renderer/components/llm/LlmPanel.tsx
+++ b/src/renderer/components/llm/LlmPanel.tsx
@@ -89,9 +89,9 @@ export function LlmPanel() {
   return (
     <div className={card.card}>
       <div className={card.header}>
-        <h2>AI Text Correction (with LLM)</h2>
+        <h2>AI Enhancement</h2>
         <p className={card.description}>
-          Improve your transcriptions by automatically fixing grammar, removing filler words, and cleaning up your speech.
+          Enhance your transcriptions by automatically fixing grammar, removing filler words, and cleaning up your speech.
         </p>
       </div>
       <div className={card.body}>
@@ -106,10 +106,10 @@ export function LlmPanel() {
                 saveConfig(true);
               }}
             />
-            <p>Improve My Transcriptions with AI</p>
+            <p>Enhance My Transcriptions with AI</p>
           </label>
           <p className={form.hint}>
-            When off, you'll get the raw Whisper transcription. When on, AI will fix grammar, remove filler words (um, uh, like), and polish your text.
+            When off, you'll get the raw Whisper transcription. When on, AI will enhance your text by fixing grammar and removing filler words.
           </p>
         </div>
 

--- a/tests/main/integration.test.ts
+++ b/tests/main/integration.test.ts
@@ -95,7 +95,7 @@ describe("Whisper-only mode integration", () => {
     const result = await pipeline.stopAndProcess();
 
     expect(result).toBe("corrected transcription");
-    expect(stagesSeen).toEqual(["transcribing", "correcting"]);
+    expect(stagesSeen).toEqual(["transcribing", "enhancing"]);
   });
 
   it("should preserve filler words in fast path (Whisper-only mode)", async () => {


### PR DESCRIPTION
## Summary
- Add config-aware status section to tray menu showing speech quality (`Speech: Balanced`) and AI enhancement state (`AI Enhancement: gpt-4o` / `AI Enhancement: Off`)
- Remove emoji icons from all tray menu items
- Rename "Show Settings" to "Show Vox" and reorder menu (Show Vox → status → actions → footer)
- Standardize all UI labels, overlay indicator, types, and logs to "enhancement/enhancing" (was mixed: "correcting", "improving", "correction")
- Rename settings tabs: "Local Model" → "Speech", "AI Improvements" → "AI Enhancement"

## Test plan
- [x] Tray menu shows status section with correct speech quality and AI state
- [x] Changing Whisper model updates tray status
- [x] Toggling AI enhancement on/off updates tray status
- [x] Changing AI provider/model reflects in tray
- [x] No emojis in tray menu items
- [x] Overlay shows "Enhancing..." instead of "Correcting..."
- [x] Settings tabs read "Speech" and "AI Enhancement"
- [x] LLM panel header and labels use "enhancement" terminology