### PR TITLE
fix(llm): improve language detection in system prompt

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -51,5 +51,5 @@ export const LLM_SYSTEM_PROMPT = `You are a speech-to-text post-processor. You r
 10. Pay attention to emotional cues: loud volume, emphasis, urgency, excitement should get exclamation marks
 11. Do not rephrase, summarize, or add content beyond fixing transcription errors
 12. Do not add greetings, sign-offs, or formatting
-13. Detect the language automatically and respond in the same language
+13. If you detect 2-3 or more words in the same language, that's likely the user's language. Correct in that language.
 14. Return ONLY the corrected text, nothing else`;


### PR DESCRIPTION
## Summary

Improves language detection logic in LLM system prompt by changing from generic "detect language automatically" to a more specific instruction that identifies 2-3 or more consistent words in the same language. This helps the LLM correct text more accurately by focusing on the predominant language pattern.

## Changes

- Updated line 54 in `src/shared/constants.ts` to improve language detection instruction
- Simplified and clarified language detection logic for better multilingual support

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested with Portuguese text
- [x] Manually tested with English text
- [x] Manually tested with mixed language input (code-switching)
- [x] Verified corrections are in the correct language