### PR TITLE
fix(ui): reorder settings tabs to place Permissions before Shortcuts

### DIFF
--- a/src/renderer/components/layout/TabNav.tsx
+++ b/src/renderer/components/layout/TabNav.tsx
@@ -29,6 +29,15 @@ const TABS: { id: string; label: string; icon: ReactNode; requiresModel?: boolea
     ),
   },
   {
+    id: "permissions",
+    label: "Permissions",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+    ),
+  },
+  {
     id: "shortcuts",
     label: "Shortcuts",
     icon: (
@@ -42,15 +51,6 @@ const TABS: { id: string; label: string; icon: ReactNode; requiresModel?: boolea
         <path d="M12 12h.01" />
         <path d="M16 12h.01" />
         <path d="M7 16h10" />
-      </svg>
-    ),
-  },
-  {
-    id: "permissions",
-    label: "Permissions",
-    icon: (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
       </svg>
     ),
   },


### PR DESCRIPTION
## Summary

Reorders settings navigation tabs in the UI to improve UX flow. Moves "Permissions" tab before "Shortcuts" tab, creating a more logical progression through settings sections.

## Changes

- Updated `src/renderer/components/layout/TabNav.tsx`
- Swapped positions in TABS array: Permissions now comes after AI Enhancement, before Shortcuts

**New tab order:**
1. Speech
2. AI Enhancement
3. Permissions (moved up)
4. Shortcuts (moved down)
5. Appearance

<img width="594" height="131" alt="image" src="https://github.com/user-attachments/assets/f7ea95c6-08d2-45cb-a411-c45ee87a7244" />

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested:
  - [x] Open Vox settings
  - [x] Verify tabs appear in new order (Permissions before Shortcuts)
  - [x] Click through each tab to ensure functionality unchanged
  - [x] Verify no visual glitches or spacing issues