### PR TITLE
feat(updates): add check for updates with GitHub releases integration

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -8,7 +8,8 @@ import { transcribe } from "./audio/whisper";
 import { createLlmProvider } from "./llm/factory";
 import { Pipeline } from "./pipeline";
 import { ShortcutManager } from "./shortcuts/manager";
-import { setupTray, setTrayModelState, updateTrayConfig } from "./tray";
+import { setupTray, setTrayModelState, updateTrayConfig, updateTrayMenu } from "./tray";
+import { checkForUpdates } from "./updater";
 import { openHome } from "./windows/home";
 import { registerIpcHandlers } from "./ipc";
 import { isAccessibilityGranted } from "./input/paster";
@@ -97,6 +98,9 @@ app.whenReady().then(async () => {
   });
   setTrayModelState(setupChecker.hasAnyModel());
   updateTrayConfig(configManager.load());
+
+  // Check for updates on startup (respects 24h cooldown)
+  checkForUpdates().then(() => updateTrayMenu());
 
   if (!app.isPackaged) {
     openHome(reloadConfig);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4,6 +4,7 @@ import { ModelManager } from "./models/manager";
 import { type VoxConfig, type WhisperModelSize } from "../shared/config";
 import { getResourcePath } from "./resources";
 import { SetupChecker } from "./setup/checker";
+import { checkForUpdates, getLastUpdateStatus } from "./updater";
 
 export function registerIpcHandlers(
   configManager: ConfigManager,
@@ -218,4 +219,9 @@ export function registerIpcHandlers(
       downloadedModels: setupChecker.getDownloadedModels(),
     };
   });
+
+  // Update checks
+  ipcMain.handle("updates:check", () => checkForUpdates(true));
+  ipcMain.handle("updates:get-status", () => getLastUpdateStatus());
+  ipcMain.handle("updates:get-version", () => app.getVersion());
 }

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,6 +1,7 @@
 import { app, Tray, Menu, nativeImage, shell } from "electron";
 import { getResourcePath } from "./resources";
 import { type VoxConfig, type WhisperModelSize } from "../shared/config";
+import { getLastUpdateStatus } from "./updater";
 
 let tray: Tray | null = null;
 
@@ -64,7 +65,7 @@ export function updateTrayConfig(config: VoxConfig): void {
   updateTrayMenu();
 }
 
-function updateTrayMenu(): void {
+export function updateTrayMenu(): void {
   if (!tray || !callbacks) return;
 
   const menuTemplate: Electron.MenuItemConstructorOptions[] = [
@@ -119,6 +120,18 @@ function updateTrayMenu(): void {
         enabled: hasModel,
       });
     }
+  }
+
+  // Update notification
+  const updateStatus = getLastUpdateStatus();
+  if (updateStatus?.updateAvailable) {
+    menuTemplate.push(
+      { type: "separator" },
+      {
+        label: `Update to v${updateStatus.latestVersion}`,
+        click: () => shell.openExternal(updateStatus.releaseUrl),
+      },
+    );
   }
 
   menuTemplate.push(

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,0 +1,113 @@
+import { app } from "electron";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface UpdateStatus {
+  updateAvailable: boolean;
+  currentVersion: string;
+  latestVersion: string;
+  releaseUrl: string;
+}
+
+interface UpdateCheckData {
+  lastCheckTimestamp: number;
+}
+
+const COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
+const GITHUB_RELEASES_URL = "https://api.github.com/repos/app-vox/vox/releases?per_page=10";
+const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+$/;
+const CHECK_FILE = "update-check.json";
+
+let cachedStatus: UpdateStatus | null = null;
+
+function getCheckFilePath(): string {
+  return path.join(app.getPath("userData"), CHECK_FILE);
+}
+
+function readCheckData(): UpdateCheckData {
+  try {
+    const data = fs.readFileSync(getCheckFilePath(), "utf-8");
+    return JSON.parse(data);
+  } catch {
+    return { lastCheckTimestamp: 0 };
+  }
+}
+
+function writeCheckData(data: UpdateCheckData): void {
+  try {
+    fs.writeFileSync(getCheckFilePath(), JSON.stringify(data));
+  } catch {
+    // Silently ignore write errors
+  }
+}
+
+function compareVersions(current: string, latest: string): number {
+  const a = current.split(".").map(Number);
+  const b = latest.split(".").map(Number);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const diff = (b[i] || 0) - (a[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+export async function checkForUpdates(force = false): Promise<UpdateStatus> {
+  const currentVersion = app.getVersion();
+
+  if (!force) {
+    const checkData = readCheckData();
+    if (Date.now() - checkData.lastCheckTimestamp < COOLDOWN_MS && cachedStatus) {
+      return cachedStatus;
+    }
+  }
+
+  try {
+    const response = await fetch(GITHUB_RELEASES_URL, {
+      headers: { "User-Agent": `Vox/${currentVersion}` },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API returned ${response.status}`);
+    }
+
+    const releases = (await response.json()) as { tag_name: string; html_url: string; draft: boolean; prerelease: boolean }[];
+
+    // Find the first release with a semver tag (skip "latest" and other non-version tags)
+    const latest = releases.find(
+      (r) => !r.draft && !r.prerelease && SEMVER_TAG_RE.test(r.tag_name),
+    );
+
+    if (latest) {
+      const latestVersion = latest.tag_name.replace(/^v/, "");
+      cachedStatus = {
+        updateAvailable: compareVersions(currentVersion, latestVersion) > 0,
+        currentVersion,
+        latestVersion,
+        releaseUrl: latest.html_url,
+      };
+    } else {
+      cachedStatus = {
+        updateAvailable: false,
+        currentVersion,
+        latestVersion: currentVersion,
+        releaseUrl: "https://github.com/app-vox/vox/releases",
+      };
+    }
+
+    writeCheckData({ lastCheckTimestamp: Date.now() });
+  } catch {
+    // Network errors should not disrupt the app
+    cachedStatus = cachedStatus ?? {
+      updateAvailable: false,
+      currentVersion,
+      latestVersion: currentVersion,
+      releaseUrl: "https://github.com/app-vox/vox/releases/latest",
+    };
+  }
+
+  return cachedStatus;
+}
+
+export function getLastUpdateStatus(): UpdateStatus | null {
+  return cachedStatus;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -31,6 +31,13 @@ export interface DownloadProgress {
   total: number;
 }
 
+export interface UpdateStatus {
+  updateAvailable: boolean;
+  currentVersion: string;
+  latestVersion: string;
+  releaseUrl: string;
+}
+
 export interface VoxAPI {
   config: {
     load(): Promise<import("../shared/config").VoxConfig>;
@@ -73,6 +80,11 @@ export interface VoxAPI {
   };
   setup: {
     check(): Promise<{ hasAnyModel: boolean; downloadedModels: string[] }>;
+  };
+  updates: {
+    check(): Promise<UpdateStatus>;
+    getStatus(): Promise<UpdateStatus | null>;
+    getVersion(): Promise<string>;
   };
 }
 
@@ -124,6 +136,11 @@ const voxApi: VoxAPI = {
   },
   setup: {
     check: () => ipcRenderer.invoke("setup:check"),
+  },
+  updates: {
+    check: () => ipcRenderer.invoke("updates:check"),
+    getStatus: () => ipcRenderer.invoke("updates:get-status"),
+    getVersion: () => ipcRenderer.invoke("updates:get-version"),
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,17 +6,17 @@ import { LlmPanel } from "./components/llm/LlmPanel";
 import { WhisperPanel } from "./components/whisper/WhisperPanel";
 import { ShortcutsPanel } from "./components/shortcuts/ShortcutsPanel";
 import { PermissionsPanel } from "./components/permissions/PermissionsPanel";
-import { AppearancePanel } from "./components/appearance/AppearancePanel";
+import { GeneralPanel } from "./components/general/GeneralPanel";
 import { SaveToast } from "./components/ui/SaveToast";
 import { useSaveToast } from "./hooks/use-save-toast";
 import { useTheme } from "./hooks/use-theme";
 
 const PANELS: Record<string, () => JSX.Element | null> = {
-  llm: LlmPanel,
+  general: GeneralPanel,
   whisper: WhisperPanel,
-  shortcuts: ShortcutsPanel,
+  llm: LlmPanel,
   permissions: PermissionsPanel,
-  appearance: AppearancePanel,
+  shortcuts: ShortcutsPanel,
 };
 
 export function App() {

--- a/src/renderer/components/general/GeneralPanel.module.scss
+++ b/src/renderer/components/general/GeneralPanel.module.scss
@@ -1,3 +1,106 @@
+.updateBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-accent);
+  border-radius: var(--radius-md);
+  color: var(--color-btn-primary-text);
+}
+
+.updateBannerContent {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+}
+
+.updateBannerActions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.downloadButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--spacing-1) var(--spacing-3);
+  background: rgb(255 255 255 / 20%);
+  border: 1px solid rgb(255 255 255 / 30%); /* stylelint-disable-line declaration-property-unit-allowed-list */
+  border-radius: var(--radius-base);
+  color: var(--color-btn-primary-text);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-default);
+  white-space: nowrap;
+
+  &:hover {
+    background: rgb(255 255 255 / 30%);
+  }
+}
+
+.dismissButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-base);
+  color: rgb(255 255 255 / 70%);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-default), background var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    color: var(--color-btn-primary-text);
+    background: rgb(255 255 255 / 15%);
+  }
+}
+
+.updateRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.upToDate {
+  font-size: var(--font-size-sm);
+  color: var(--color-success);
+  font-weight: var(--font-weight-medium);
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+.aboutHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.aboutLogo {
+  width: 60px;
+  height: 60px;
+  border-radius: var(--radius-lg);
+}
+
+.aboutDivider {
+  height: 1px;
+  background: var(--color-border);
+  margin: var(--spacing-4) 0;
+}
+
 .segmented {
   display: inline-flex;
   background: var(--color-bg-input);
@@ -40,7 +143,6 @@
   padding: var(--spacing-1) 0;
 
   input[type="checkbox"] {
-    appearance: none;
     appearance: none;
     width: 18px;
     height: 18px;
@@ -132,6 +234,16 @@
   &:hover {
     background: var(--color-bg-hover);
     border-color: var(--color-border-hover);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+
+    &:hover {
+      background: none;
+      border-color: var(--color-border);
+    }
   }
 
   svg:first-child {

--- a/src/renderer/components/layout/TabNav.tsx
+++ b/src/renderer/components/layout/TabNav.tsx
@@ -5,6 +5,16 @@ import styles from "./TabNav.module.scss";
 
 const TABS: { id: string; label: string; icon: ReactNode; requiresModel?: boolean }[] = [
   {
+    id: "general",
+    label: "General",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+    ),
+  },
+  {
     id: "whisper",
     label: "Speech",
     requiresModel: true,
@@ -51,16 +61,6 @@ const TABS: { id: string; label: string; icon: ReactNode; requiresModel?: boolea
         <path d="M12 12h.01" />
         <path d="M16 12h.01" />
         <path d="M7 16h10" />
-      </svg>
-    ),
-  },
-  {
-    id: "appearance",
-    label: "Appearance",
-    icon: (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="12" r="3" />
-        <path d="M12 1v6m0 6v6m5.2-17.2l-4.2 4.2m-2 2l-4.2 4.2M23 12h-6m-6 0H1m17.2 5.2l-4.2-4.2m-2-2l-4.2-4.2" />
       </svg>
     ),
   },

--- a/src/renderer/stores/config-store.ts
+++ b/src/renderer/stores/config-store.ts
@@ -2,6 +2,11 @@ import { create } from "zustand";
 import type { VoxConfig } from "../../shared/config";
 import { useSaveToast } from "../hooks/use-save-toast";
 
+function migrateActiveTab(tab: string | null): string | null {
+  if (tab === "appearance") return "general";
+  return tab;
+}
+
 interface ConfigState {
   config: VoxConfig | null;
   loading: boolean;
@@ -17,7 +22,7 @@ interface ConfigState {
 export const useConfigStore = create<ConfigState>((set, get) => ({
   config: null,
   loading: true,
-  activeTab: typeof window !== "undefined" ? (localStorage.getItem("vox:activeTab") || "whisper") : "whisper",
+  activeTab: typeof window !== "undefined" ? (migrateActiveTab(localStorage.getItem("vox:activeTab")) || "general") : "general",
   setupComplete: false,
 
   setActiveTab: (tab) => {
@@ -35,8 +40,8 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
     const setupState = await window.voxApi.setup.check();
 
     // Force Whisper tab if setup is incomplete
-    const savedTab = typeof window !== "undefined" ? localStorage.getItem("vox:activeTab") : null;
-    const activeTab = setupState.hasAnyModel ? (savedTab || "whisper") : "whisper";
+    const savedTab = typeof window !== "undefined" ? migrateActiveTab(localStorage.getItem("vox:activeTab")) : null;
+    const activeTab = setupState.hasAnyModel ? (savedTab || "general") : "whisper";
 
     set({
       config,


### PR DESCRIPTION
## Summary
- Add update checker module that queries GitHub Releases API, compares semver versions, and caches results with 24h cooldown
- Rename **Appearance** tab to **General** and move it to first position with a gear icon
- Merge **Updates** and **Help & Support** into a unified **About** card with Vox logo, version display, check-for-updates button, and report issue link
- Show conditional **"Update to vX.Y.Z"** item in tray menu when a newer version is detected
- Add IPC bridge (`updates:check`, `updates:get-status`, `updates:get-version`) and preload API
- In-app banner with Download button (opens GitHub release page) and per-session dismiss

### Screenshot

> **Note:** Upload the screenshot of the General tab to the PR description via the GitHub web UI (drag and drop the image into the edit box).

## Test plan
- [x] `npm run dev` — verify "General" tab appears first with gear icon
- [x] Click "Check for Updates" — should show "You're up to date" or update banner
- [x] Change `package.json` version to a lower value, delete `~/Library/Application Support/vox/update-check.json`, restart — banner should appear
- [x] Dismiss banner — should disappear until settings window is re-opened
- [x] Right-click tray — "Update to vX.Y.Z" should appear when update is available
- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no lint errors
- [x] `npm run test` — all tests pass

<img width="700" height="841" alt="image" src="https://github.com/user-attachments/assets/8921fd08-8483-4678-b465-1048d9d381b9" />
<img width="648" height="255" alt="image" src="https://github.com/user-attachments/assets/0b2cfaa9-2477-4b9e-b086-c856d8f69583" />
<img width="289" height="245" alt="image" src="https://github.com/user-attachments/assets/10626afa-1d9a-4587-ab17-8619dd75f4d2" />

