### PR TITLE
fix(deploy): include i18n.js in GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Minify JavaScript
         run: |
+          terser i18n.js -o dist/i18n.js -c -m
           terser script.js -o dist/script.js -c -m
 
       - name: Copy assets


### PR DESCRIPTION
## Problem

After merging #108, the `i18n.js` file returns 404 on the deployed site:
https://app-vox.github.io/vox/i18n.js

## Root Cause

The deployment workflow (`.github/workflows/deploy-landing-page.yml`) was minifying and copying `script.js` but not `i18n.js`.

## Solution

Added terser minification step for `i18n.js` before `script.js` in the workflow.

## Testing

✅ Tested locally - `i18n.js` loads correctly (HTTP 200)
✅ HTML correctly references both scripts in order: `i18n.js` → `script.js`

## Impact

After merging, the next deployment will include `i18n.js` and the landing page i18n will work properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)