### PR TITLE
fix(ci): mark latest release as prerelease for electron-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,8 +255,11 @@ jobs:
           git tag -f latest
           git push origin latest
 
-          # Create the latest release with stable-name assets
+          # Create the latest release as a prerelease so electron-updater
+          # skips it and resolves to the versioned release (which has
+          # matching file names for latest-mac.yml).
           gh release create latest \
+            --prerelease \
             --title "Vox Latest ($TAG)" \
             --notes "$(cat <<'NOTES'
           This release always points to the latest version. Current: **$TAG**


### PR DESCRIPTION
## Summary
- Mark the `latest` tagged GitHub release as a **prerelease** so `electron-updater` skips it
- `electron-updater` resolves to GitHub's "latest" release via API, which returned the `latest` tagged release — that release has stable-named files (`Vox-mac-arm64.zip`) that don't match the file names in `latest-mac.yml` (`Vox-0.2.0-arm64-mac.zip`), causing a 404 at runtime
- With `--prerelease`, `electron-updater` now resolves to the versioned release (e.g. `v0.2.0`) which has matching file names

## Test plan
- [ ] Verify `electron-updater` no longer returns 404 for `latest-mac.yml`
- [ ] Verify the `latest` tagged release is still accessible for manual downloads
- [ ] Next release workflow creates the `latest` release with `--prerelease` flag