### PR TITLE
fix(tray): adjust tray icon size for better vertical alignment in macOS

### DIFF
--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -43,7 +43,9 @@ export function setupTray(trayCallbacks: TrayCallbacks): void {
   callbacks = trayCallbacks;
 
   const iconPath = getResourcePath("trayIcon.png");
-  const icon = nativeImage.createFromPath(iconPath);
+  let icon = nativeImage.createFromPath(iconPath);
+  // Resize to 18x18 to provide better vertical alignment in macOS menu bar
+  icon = icon.resize({ width: 18, height: 18 });
   icon.setTemplateImage(true);
   tray = new Tray(icon);
 


### PR DESCRIPTION
## Summary

Reduced tray icon size from 22x22 to 18x18 pixels to provide better vertical alignment in the macOS menu bar. The icon was appearing slightly higher than conventional menu bar icons due to the default 22x22 size without adequate internal padding.

## Changes

- Resize tray icon to 18x18 pixels before setting as template image
- Add inline comment explaining the resize rationale

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested: Built and verified tray icon appears with proper vertical alignment in macOS menu bar, comparable to other native menu bar icons

<img width="187" height="29" alt="image" src="https://github.com/user-attachments/assets/e45a104e-5887-4cca-b0b0-8b1b03ba181b" />
