### PR TITLE
fix(landing): improve mobile layout for how it works section

### DIFF
--- a/style.css
+++ b/style.css
@@ -456,10 +456,16 @@ body {
     background-color: var(--bg-secondary);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-xl);
-    padding: var(--spacing-lg);
+    padding: 1rem;
     max-width: 900px;
     margin: 0 auto;
     transition: all var(--transition-base);
+}
+
+@media (min-width: 640px) {
+    .demo-container {
+        padding: 1.5rem;
+    }
 }
 
 @media (min-width: 768px) {
@@ -658,6 +664,8 @@ body {
     font-size: 0.8125rem;
     font-weight: 600;
     margin-bottom: 0.125rem;
+    word-break: break-word;
+    hyphens: auto;
 }
 
 @media (min-width: 768px) {
@@ -671,6 +679,8 @@ body {
     font-size: 0.6875rem;
     color: var(--text-secondary);
     line-height: 1.3;
+    word-break: break-word;
+    hyphens: auto;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- Reduced padding in "How it works" container for mobile (1rem) and tablet (1.5rem) to prevent squeezed content
- Added word-break and hyphenation to stage labels for better mobile display
- Stage labels (Record, Transcribe, AI Enhancement, Paste) now display one word per line on mobile
- Maintained desktop padding (2rem) for optimal spacing

## Test plan
- [x] Open landing page on mobile device (or browser mobile view)
- [x] Verify "How it works" section has adequate padding and content is not squeezed
- [x] Verify stage labels break properly into single words on narrow screens
- [x] Test on tablet view (640px-768px width) to ensure 1.5rem padding
- [x] Verify desktop view maintains 2rem padding

<img width="335" height="656" alt="image" src="https://github.com/user-attachments/assets/0f13b24b-3be4-4813-9d6a-2638d140df68" />
