### PR TITLE
fix(ux): always show settings window on startup and fix tray Show Vox

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -149,9 +149,7 @@ app.whenReady().then(async () => {
 
   initAutoUpdater(() => updateTrayMenu());
 
-  if (!app.isPackaged || !setupChecker.hasAnyModel()) {
-    openHome(reloadConfig);
-  }
+  openHome(reloadConfig);
 });
 
 app.on("activate", () => {

--- a/src/main/windows/home.ts
+++ b/src/main/windows/home.ts
@@ -14,12 +14,17 @@ let homeWindow: BrowserWindow | null = null;
 
 export function openHome(onClosed: () => void, initialTab?: string): void {
   if (homeWindow) {
-    homeWindow.show();
-    homeWindow.focus();
-    if (initialTab) {
-      homeWindow.webContents.send("navigate-tab", initialTab);
+    if (homeWindow.isDestroyed()) {
+      homeWindow = null;
+    } else {
+      if (homeWindow.isMinimized()) homeWindow.restore();
+      homeWindow.show();
+      homeWindow.focus();
+      if (initialTab) {
+        homeWindow.webContents.send("navigate-tab", initialTab);
+      }
+      return;
     }
-    return;
   }
 
   const cursorPoint = screen.getCursorScreenPoint();


### PR DESCRIPTION
## Summary
- Always open the settings (home) window when the app starts, instead of only when unpackaged or missing a Whisper model
- Fix intermittent failure of tray "Show Vox" action by adding `isDestroyed()` and `isMinimized()` checks before reusing the existing window reference

## Details

**Startup behavior (`app.ts`):** The conditional `if (!app.isPackaged || !setupChecker.hasAnyModel())` meant the window would not open on launch for packaged builds with a model already configured. Removed the condition so `openHome()` is always called.

**Tray "Show Vox" bug (`windows/home.ts`):** The `openHome` function only checked if `homeWindow` was truthy before calling `show()` + `focus()`. Two scenarios caused silent failures:
1. **Minimized window** — `show()` alone doesn't restore a minimized window on macOS; `restore()` is needed first
2. **Stale reference** — if the window was destroyed without the `closed` event clearing the reference, `show()`/`focus()` on a destroyed `BrowserWindow` fail silently

Added `isDestroyed()` and `isMinimized()` checks, matching the defensive pattern already used in `recorder.ts`.

## Test plan
- [ ] Launch the packaged app — settings window should appear automatically
- [ ] Close the settings window, then click "Show Vox" in tray — window should reopen
- [ ] Minimize the settings window (Cmd+M), then click "Show Vox" — window should restore
- [ ] Rapidly click "Show Vox" multiple times — window should always appear