### PR TITLE
fix(ci): remove separate latest release, use GitHub built-in latest URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
           # Move all build artifacts to release directory
           find artifacts -type f \( -name "*.dmg" -o -name "*.zip" -o -name "*.blockmap" -o -name "latest-mac.yml" \) -exec mv {} release/ \;
 
-          # Create stable-named copies for the latest release
+          # Create stable-named copies for releases/latest/download URLs
           DMG=$(find release -name "*.dmg" ! -name "Vox-mac-arm64.dmg" | head -1)
           ZIP=$(find release -name "*-mac.zip" | head -1)
           cp "$DMG" "release/Vox-mac-arm64.dmg"
@@ -209,7 +209,7 @@ jobs:
           git commit -m "chore(release): bump version to ${{ needs.version.outputs.version }}"
           git push origin HEAD:main
 
-      - name: Create versioned GitHub Release
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -219,45 +219,17 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
+          # Upload both versioned and stable-named assets so that
+          # GitHub's built-in releases/latest/download/<asset> provides
+          # permanent download URLs without a separate "latest" release.
           gh release create "$TAG" \
             --title "Vox $TAG" \
             --generate-notes \
             release/Vox-${VERSION}-arm64.dmg \
             release/Vox-${VERSION}-arm64-mac.zip \
             release/Vox-${VERSION}-arm64-mac.zip.blockmap \
-            release/latest-mac.yml
-
-          echo "Versioned release created: $TAG"
-
-      - name: Update latest release
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          TAG="${{ needs.version.outputs.tag }}"
-
-          # Delete existing latest release and tag if they exist
-          # Use GitHub API instead of git push to avoid tag protection rules
-          gh release delete latest --yes --cleanup-tag 2>/dev/null || true
-
-          # Create the latest release as a prerelease so electron-updater
-          # skips it and resolves to the versioned release (which has
-          # matching file names for latest-mac.yml).
-          # --target creates the tag via the API, bypassing git push restrictions.
-          gh release create latest \
-            --target "$(git rev-parse HEAD)" \
-            --prerelease \
-            --title "Vox Latest ($TAG)" \
-            --notes "$(cat <<NOTES
-          This release always points to the latest version. Current: **${TAG}**
-
-          ### Download
-
-          **Apple Silicon (M1/M2/M3/M4):**
-          - [Vox-mac-arm64.dmg](https://github.com/app-vox/vox/releases/download/latest/Vox-mac-arm64.dmg)
-          - [Vox-mac-arm64.zip](https://github.com/app-vox/vox/releases/download/latest/Vox-mac-arm64.zip)
-          NOTES
-          )" \
+            release/latest-mac.yml \
             release/Vox-mac-arm64.dmg \
             release/Vox-mac-arm64.zip
 
-          echo "Latest release updated"
+          echo "Release created: $TAG"


### PR DESCRIPTION
## Summary
- Remove the "Update latest release" step that fails with `GH013: Cannot create ref due to creations being restricted` when trying to create/recreate the `latest` tag
- Upload stable-named assets (`Vox-mac-arm64.dmg`, `Vox-mac-arm64.zip`) to the versioned release instead
- GitHub's built-in `releases/latest/download/<asset>` URL automatically redirects to the newest non-prerelease release, providing the same stable download links without a custom tag

## Context
Both previous attempts to fix the `latest` tag creation failed:
- `git push origin latest` → blocked by repository rule (GH013)
- `gh release create latest --target` → also blocked (`HTTP 422: pre_receive Repository rule violations`)

The root cause is a tag protection rule (likely org-level) that blocks creating the `latest` tag. Since versioned tags (`v0.x.0`) work fine, the simplest fix is to stop using a separate `latest` tag entirely.

**Download URLs change from:**
```
https://github.com/app-vox/vox/releases/download/latest/Vox-mac-arm64.dmg
```
**To:**
```
https://github.com/app-vox/vox/releases/latest/download/Vox-mac-arm64.dmg
```

The README already uses `releases/latest` so no docs changes are needed.

## Test plan
- [ ] Trigger a release workflow run and verify the "Create GitHub Release" step succeeds
- [ ] Verify the release contains both versioned and stable-named assets
- [ ] Verify `https://github.com/app-vox/vox/releases/latest/download/Vox-mac-arm64.dmg` resolves correctly