### PR TITLE
fix(site): update download URL to use GitHub built-in latest redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             "name": "Vox Community"
         },
         "url": "https://app-vox.github.io/vox/",
-        "downloadUrl": "https://github.com/app-vox/vox/releases/download/latest/Vox-mac-arm64.dmg",
+        "downloadUrl": "https://github.com/app-vox/vox/releases/latest/download/Vox-mac-arm64.dmg",
         "softwareRequirements": "macOS 12+, Apple Silicon",
         "license": "https://github.com/app-vox/vox/blob/main/LICENSE"
     }
@@ -155,7 +155,7 @@
                         <span class="text-accent" data-i18n="hero.titleAccent">Secure. Accurate. Free.</span>
                     </h1>
                     <div class="hero-cta">
-                        <a href="https://github.com/app-vox/vox/releases/download/latest/Vox-mac-arm64.dmg" class="btn btn-primary" id="download-btn" target="_blank" rel="noopener noreferrer">
+                        <a href="https://github.com/app-vox/vox/releases/latest/download/Vox-mac-arm64.dmg" class="btn btn-primary" id="download-btn" target="_blank" rel="noopener noreferrer">
                             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                                 <path d="M8.75 1.75a.75.75 0 00-1.5 0v5.69L5.03 5.22a.75.75 0 00-1.06 1.06l3.5 3.5a.75.75 0 001.06 0l3.5-3.5a.75.75 0 00-1.06-1.06L8.75 7.44V1.75z"/>
                                 <path d="M2.5 9.5a.75.75 0 01.75.75v2.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0112 15H4a1.75 1.75 0 01-1.75-1.75v-2.5a.75.75 0 01.75-.75z"/>


### PR DESCRIPTION
## Summary
- Update download URLs from `releases/download/latest/` (custom `latest` tag) to `releases/latest/download/` (GitHub's built-in redirect to newest release)
- Affects JSON-LD structured data and the hero download button

## Context
Companion to #162 — the release workflow no longer maintains a separate `latest` release/tag. Stable-named assets (`Vox-mac-arm64.dmg`) are now uploaded to the versioned release, and GitHub's built-in `releases/latest` redirect handles the rest.

## Test plan
- [ ] Verify `https://github.com/app-vox/vox/releases/latest/download/Vox-mac-arm64.dmg` resolves after next release
- [ ] Verify download button on the landing page works