### PR TITLE
fix(permissions): stale warning badge after granting microphone permission

### DIFF
--- a/src/renderer/hooks/use-permissions.ts
+++ b/src/renderer/hooks/use-permissions.ts
@@ -1,26 +1,15 @@
-import { useState, useCallback, useEffect } from "react";
-import type { PermissionsStatus } from "../../preload/index";
+import { useEffect } from "react";
+import { usePermissionsStore } from "../stores/permissions-store";
 
 export function usePermissions() {
-  const [status, setStatus] = useState<PermissionsStatus | null>(null);
-
-  const refresh = useCallback(async () => {
-    const s = await window.voxApi.permissions.status();
-    setStatus(s);
-  }, []);
+  const status = usePermissionsStore((s) => s.status);
+  const refresh = usePermissionsStore((s) => s.refresh);
+  const requestMicrophone = usePermissionsStore((s) => s.requestMicrophone);
+  const requestAccessibility = usePermissionsStore((s) => s.requestAccessibility);
 
   useEffect(() => {
-    window.voxApi.permissions.status().then(setStatus);
-  }, []);
-
-  const requestMicrophone = useCallback(async () => {
-    await window.voxApi.permissions.requestMicrophone();
-    await refresh();
-  }, [refresh]);
-
-  const requestAccessibility = useCallback(async () => {
-    await window.voxApi.permissions.requestAccessibility();
-  }, []);
+    if (status === null) refresh();
+  }, [status, refresh]);
 
   return { status, refresh, requestMicrophone, requestAccessibility };
 }

--- a/src/renderer/stores/permissions-store.ts
+++ b/src/renderer/stores/permissions-store.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import type { PermissionsStatus } from "../../preload/index";
+
+interface PermissionsState {
+  status: PermissionsStatus | null;
+  refresh: () => Promise<void>;
+  requestMicrophone: () => Promise<void>;
+  requestAccessibility: () => Promise<void>;
+}
+
+export const usePermissionsStore = create<PermissionsState>((set, get) => ({
+  status: null,
+
+  refresh: async () => {
+    const s = await window.voxApi.permissions.status();
+    set({ status: s });
+  },
+
+  requestMicrophone: async () => {
+    await window.voxApi.permissions.requestMicrophone();
+    await get().refresh();
+  },
+
+  requestAccessibility: async () => {
+    await window.voxApi.permissions.requestAccessibility();
+  },
+}));


### PR DESCRIPTION
## Summary
- The permissions tab warning badge in the sidebar persisted after granting microphone permission because `usePermissions()` used local React state (`useState`), giving each consumer component its own independent copy
- Only `PermissionsPanel` refreshed on window focus/tab change — `Sidebar` and `GeneralPanel` never re-fetched, keeping stale "denied" status
- Replaced local state with a shared Zustand store (`permissions-store.ts`) so all consumers reactively update when any component triggers a refresh

## Test plan
- [ ] Start the app without microphone permission granted
- [ ] Verify the red warning badge appears on the permissions tab in the sidebar
- [ ] Grant microphone permission via System Settings
- [ ] Return to the app — the warning badge should disappear and the green checkmark should appear (once accessibility is also granted)
- [ ] Verify `npx vitest run` passes (115 tests)
- [ ] Verify `npx tsc --noEmit` has no type errors