### PR TITLE
docs(templates): add code standards checklist to issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,17 @@ What actually happens.
 
 ## Environment
 
-- macOS version:
+- OS / version:
 - Vox version:
 - Whisper model:
-- LLM provider: Foundry / Bedrock / None
+- LLM provider: Foundry / Bedrock / OpenAI / DeepSeek / Anthropic / LiteLLM / Custom / None
+
+## Code Standards Checklist
+
+> Before submitting a fix, ensure the following are addressed:
+
+- [ ] **i18n** — All user-facing strings use the translation system (`useT()` / `t()`). New keys added to `en.json` **and all other locale files**.
+- [ ] **Dev Panel state** — If this fix changes or reveals internal state, consider exposing it in the Dev Panel (#157) for easier future debugging.
+- [ ] **CSS** — Use CSS Modules with CSS custom properties (variables) for colors, spacing, and theming. No hardcoded hex/rgb values.
+- [ ] **SVGs** — SVG assets live in their own files (not inlined in TSX). Import them as components or image sources.
+- [ ] **No hardcoded strings** — Log messages are fine, but anything the user sees must go through i18n.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or Discussion
+    url: https://github.com/app-vox/vox/discussions
+    about: Ask questions or start a discussion instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,3 +16,14 @@ How should this work?
 ## Alternatives considered
 
 Any alternative approaches you've thought of.
+
+## Code Standards Checklist
+
+> Before implementing, ensure the following are considered in the design and implementation:
+
+- [ ] **i18n** — All user-facing strings use the translation system (`useT()` / `t()`). New keys added to `en.json` **and all other locale files**.
+- [ ] **Dev Panel state** — If this feature introduces new internal state, consider exposing it in the Dev Panel (#157) for runtime inspection and debugging.
+- [ ] **CSS** — Use CSS Modules with CSS custom properties (variables) for colors, spacing, and theming. No hardcoded hex/rgb values.
+- [ ] **SVGs** — SVG assets live in their own files (not inlined in TSX). Import them as components or image sources.
+- [ ] **No hardcoded strings** — Log messages are fine, but anything the user sees must go through i18n.
+- [ ] **Accessibility** — Interactive elements are keyboard-navigable and have appropriate ARIA attributes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,11 @@ Brief description of the changes.
 - [ ] `npm run lint` passes
 - [ ] `npm test` passes
 - [ ] Manually tested (describe how)
+
+## Code standards
+
+- [ ] **i18n** — All user-facing strings use the translation system. New keys added to **all** locale files.
+- [ ] **Dev Panel** — New internal state is exposed in the Dev Panel where useful for debugging.
+- [ ] **CSS** — CSS Modules with CSS custom properties. No hardcoded color/spacing values.
+- [ ] **SVGs** — SVG assets in separate files, not inlined in TSX.
+- [ ] **Accessibility** — Interactive elements are keyboard-navigable with appropriate ARIA attributes.


### PR DESCRIPTION
## Summary

Adds a **Code Standards Checklist** to all issue and PR templates so every contributor is reminded of Vox's conventions before submitting.

## Changes

- **Bug Report template**: Added code standards checklist, updated LLM provider list (was only "Foundry / Bedrock / None", now lists all 7), generalized "macOS version" → "OS / version"
- **Feature Request template**: Added code standards checklist with accessibility item
- **PR template**: Added code standards section matching the issue templates
- **config.yml** (new): Disables blank issues, adds link to Discussions for questions

### Checklist items added to all templates

| Item | Why |
|------|-----|
| **i18n** | All user-facing strings must use `useT()`/`t()` with keys in all locale files |
| **Dev Panel state** | New state should be exposed in the Dev Panel (#157) for debugging |
| **CSS** | CSS Modules with CSS custom properties — no hardcoded colors/spacing |
| **SVGs** | Separate files, not inlined in TSX |
| **Accessibility** | Keyboard nav + ARIA attributes (feature request & PR templates) |

## Test plan

- [ ] Bug report template renders correctly on GitHub with checklist
- [ ] Feature request template renders correctly on GitHub with checklist
- [ ] PR template renders correctly on GitHub with checklist
- [ ] config.yml disables blank issues and shows Discussions link
- [ ] "New Issue" page shows only Bug Report and Feature Request options