### PR TITLE
fix(ui): UX improvements across multiple panels

### DIFF
--- a/src/renderer/components/about/AboutPanel.module.scss
+++ b/src/renderer/components/about/AboutPanel.module.scss
@@ -25,8 +25,15 @@
   margin-left: auto;
 }
 
-.progressBar {
+.progressRow {
   grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.progressBar {
+  flex: 1;
   height: 4px;
   background: rgb(255 255 255 / 20%);
   border-radius: 2px;

--- a/src/renderer/components/about/AboutPanel.tsx
+++ b/src/renderer/components/about/AboutPanel.tsx
@@ -101,32 +101,38 @@ export function AboutPanel() {
                   </>
                 )}
               </div>
-              {status === "downloading" && (
-                <div className={styles.progressBar}>
-                  <div
-                    className={styles.progressFill}
-                    style={{ width: `${devDownloadProgress ?? updateState?.downloadProgress ?? 0}%` }}
-                  />
+              {status === "downloading" ? (
+                <div className={styles.progressRow}>
+                  <div className={styles.progressBar}>
+                    <div
+                      className={styles.progressFill}
+                      style={{ width: `${devDownloadProgress ?? updateState?.downloadProgress ?? 0}%` }}
+                    />
+                  </div>
+                  <button onClick={() => setDismissed(true)} className={styles.dismissButton} aria-label="Dismiss">
+                    <XIcon width={14} height={14} />
+                  </button>
+                </div>
+              ) : (
+                <div className={styles.updateBannerActions}>
+                  {status === "ready" ? (
+                    <button onClick={handleRestart} className={styles.downloadButton}>
+                      {t("general.about.restartNow")}
+                    </button>
+                  ) : status === "available" && isDevMode && updateState?.releaseUrl ? (
+                    <button
+                      onClick={() => window.voxApi.shell.openExternal(updateState.releaseUrl)}
+                      className={styles.downloadButton}
+                    >
+                      {t("general.about.download")}
+                      <ExternalLinkIcon width={14} height={14} />
+                    </button>
+                  ) : null}
+                  <button onClick={() => setDismissed(true)} className={styles.dismissButton} aria-label="Dismiss">
+                    <XIcon width={14} height={14} />
+                  </button>
                 </div>
               )}
-              <div className={styles.updateBannerActions}>
-                {status === "ready" ? (
-                  <button onClick={handleRestart} className={styles.downloadButton}>
-                    {t("general.about.restartNow")}
-                  </button>
-                ) : status === "available" && isDevMode && updateState?.releaseUrl ? (
-                  <button
-                    onClick={() => window.voxApi.shell.openExternal(updateState.releaseUrl)}
-                    className={styles.downloadButton}
-                  >
-                    {t("general.about.download")}
-                    <ExternalLinkIcon width={14} height={14} />
-                  </button>
-                ) : null}
-                <button onClick={() => setDismissed(true)} className={styles.dismissButton} aria-label="Dismiss">
-                  <XIcon width={14} height={14} />
-                </button>
-              </div>
             </div>
             <button onClick={openIssueTracker} className={styles.reportIssueBelow}>
               <InfoCircleAltIcon width={16} height={16} />

--- a/src/renderer/components/dev/DevOverrideBadge.tsx
+++ b/src/renderer/components/dev/DevOverrideBadge.tsx
@@ -1,3 +1,4 @@
+import { XIcon } from "../../../shared/icons";
 import { useDevOverrides } from "../../stores/dev-overrides-store";
 import { useConfigStore } from "../../stores/config-store";
 import styles from "../layout/Titlebar.module.scss";
@@ -5,16 +6,29 @@ import styles from "../layout/Titlebar.module.scss";
 export function DevOverrideBadge() {
   const enabled = useDevOverrides((s) => s.overrides.enabled);
   const hideDevVisuals = useDevOverrides((s) => s.overrides.hideDevVisuals);
+  const clearAll = useDevOverrides((s) => s.clearAll);
   const setActiveTab = useConfigStore((s) => s.setActiveTab);
 
   if (!enabled) return null;
 
   return (
-    <button
-      className={`${styles.overrideBadge} ${hideDevVisuals === true ? styles.devHidden : ""}`}
-      onClick={() => setActiveTab("dev")}
-    >
-      {"Overrides Active"}
-    </button>
+    <div className={`${styles.overrideBadgeGroup} ${hideDevVisuals === true ? styles.devHidden : ""}`}>
+      <button
+        className={styles.overrideClear}
+        onClick={(e) => {
+          e.stopPropagation();
+          clearAll();
+        }}
+        aria-label="Clear all overrides"
+      >
+        <XIcon width={10} height={10} />
+      </button>
+      <button
+        className={styles.overrideBadge}
+        onClick={() => setActiveTab("dev")}
+      >
+        {"Overrides Active"}
+      </button>
+    </div>
   );
 }

--- a/src/renderer/components/dev/DevPanel.tsx
+++ b/src/renderer/components/dev/DevPanel.tsx
@@ -427,28 +427,6 @@ export function DevPanel() {
       ],
     },
     {
-      title: "Recording / Pipeline",
-      rows: [
-        { label: "Recording", render: () => <>{runtime ? boolDot(runtime.isRecording) : <Dot color="gray" />}</> },
-        { label: "Shortcut State", render: () => <>{runtime ? statusDot(runtime.shortcutState) : <Dot color="gray" />}</> },
-      ],
-    },
-    {
-      title: "Indicator",
-      rows: [
-        { label: "Visible", render: () => <>{runtime ? boolDot(runtime.indicatorVisible) : <Dot color="gray" />}</> },
-        { label: "Mode", render: () => <>{runtime ? statusDot(runtime.indicatorMode) : <Dot color="gray" />}</> },
-      ],
-    },
-    {
-      title: "Tray",
-      rows: [
-        { label: "Active", render: () => <>{runtime ? boolDot(runtime.trayActive) : <Dot color="gray" />}</> },
-        { label: "Listening", render: () => <>{runtime ? boolDot(runtime.isListening) : <Dot color="gray" />}</> },
-        { label: "Has Model", render: () => <>{runtime ? boolDot(runtime.hasModel) : <Dot color="gray" />}</> },
-      ],
-    },
-    {
       title: "LLM",
       overrideFields: ["llmEnhancementEnabled", "llmConnectionTested"],
       rows: [
@@ -488,6 +466,28 @@ export function DevPanel() {
       rows: [
         { label: "Model", render: () => <>{selectedModel}</> },
         { label: "Downloaded", render: () => <>{downloadedModels.length > 0 ? downloadedModels.join(", ") : "(none)"}</> },
+      ],
+    },
+    {
+      title: "Recording / Pipeline",
+      rows: [
+        { label: "Recording", render: () => <>{runtime ? boolDot(runtime.isRecording) : <Dot color="gray" />}</> },
+        { label: "Shortcut State", render: () => <>{runtime ? statusDot(runtime.shortcutState) : <Dot color="gray" />}</> },
+      ],
+    },
+    {
+      title: "Indicator",
+      rows: [
+        { label: "Visible", render: () => <>{runtime ? boolDot(runtime.indicatorVisible) : <Dot color="gray" />}</> },
+        { label: "Mode", render: () => <>{runtime ? statusDot(runtime.indicatorMode) : <Dot color="gray" />}</> },
+      ],
+    },
+    {
+      title: "Tray",
+      rows: [
+        { label: "Active", render: () => <>{runtime ? boolDot(runtime.trayActive) : <Dot color="gray" />}</> },
+        { label: "Listening", render: () => <>{runtime ? boolDot(runtime.isListening) : <Dot color="gray" />}</> },
+        { label: "Has Model", render: () => <>{runtime ? boolDot(runtime.hasModel) : <Dot color="gray" />}</> },
       ],
     },
     {

--- a/src/renderer/components/dictionary/DictionaryPanel.tsx
+++ b/src/renderer/components/dictionary/DictionaryPanel.tsx
@@ -3,7 +3,7 @@ import { useConfigStore } from "../../stores/config-store";
 import { useDevOverrideValue } from "../../hooks/use-dev-override";
 import { useT } from "../../i18n-context";
 import { computeLlmConfigHash } from "../../../shared/llm-config-hash";
-import { XIcon, ChevronLeftIcon, ChevronRightIcon, InfoCircleIcon } from "../../../shared/icons";
+import { XIcon, ChevronsLeftIcon, ChevronLeftIcon, ChevronRightIcon, ChevronsRightIcon, InfoCircleIcon } from "../../../shared/icons";
 import { CustomSelect } from "../ui/CustomSelect";
 import card from "../shared/card.module.scss";
 import form from "../shared/forms.module.scss";
@@ -50,6 +50,12 @@ export function DictionaryPanel() {
     ? useDevOverrideValue("llmEnhancementEnabled", realLlmEnabled)
     : realLlmEnabled;
 
+  const realLlmTested = useConfigStore((s) => s.config?.llmConnectionTested ?? false);
+  const llmTested = import.meta.env.DEV
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    ? useDevOverrideValue("llmConnectionTested", realLlmTested)
+    : realLlmTested;
+
   const showInfoBanner = !setupComplete || !llmEnabled;
 
   const [inputValue, setInputValue] = useState("");
@@ -64,8 +70,8 @@ export function DictionaryPanel() {
 
   if (!config) return null;
 
-  const llmReady = config.enableLlmEnhancement === true
-    && config.llmConnectionTested === true
+  const llmReady = llmEnabled === true
+    && llmTested === true
     && computeLlmConfigHash(config) === config.llmConfigHash;
 
   const dictionary = config.dictionary ?? [];
@@ -156,18 +162,12 @@ export function DictionaryPanel() {
 
       {llmEnabled && !llmReady && (
         <div className={card.warningBanner}>
+          <InfoCircleIcon width={16} height={16} />
           <span>
             {t("dictionary.llmRequired")}{" "}
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                useConfigStore.getState().setActiveTab("llm");
-              }}
-              style={{ color: "inherit", textDecoration: "underline", cursor: "pointer" }}
-            >
-              {t("tabs.aiEnhancement")}
-            </a>
+            <button className={card.infoBannerLink} onClick={() => setActiveTab("llm")}>
+              {t("dictionary.goToAiEnhancement")}
+            </button>
           </span>
         </div>
       )}
@@ -227,12 +227,22 @@ export function DictionaryPanel() {
                   {page} / {totalPages || 1}
                 </div>
                 <div className={styles.pageControls}>
+                  {page > 2 && (
+                    <button onClick={() => setPage(1)}>
+                      <ChevronsLeftIcon width={12} height={12} />
+                    </button>
+                  )}
                   <button disabled={page <= 1} onClick={() => setPage(page - 1)}>
                     <ChevronLeftIcon width={12} height={12} />
                   </button>
                   <button disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
                     <ChevronRightIcon width={12} height={12} />
                   </button>
+                  {page < totalPages - 1 && (
+                    <button onClick={() => setPage(totalPages)}>
+                      <ChevronsRightIcon width={12} height={12} />
+                    </button>
+                  )}
                 </div>
                 {/* eslint-disable i18next/no-literal-string */}
                 <div className={styles.pageSizeSelect}>

--- a/src/renderer/components/general/GeneralPanel.tsx
+++ b/src/renderer/components/general/GeneralPanel.tsx
@@ -5,7 +5,7 @@ import { usePermissions } from "../../hooks/use-permissions";
 import { useDevOverrideValue } from "../../hooks/use-dev-override";
 import { useT } from "../../i18n-context";
 import { SUPPORTED_LANGUAGES } from "../../../shared/i18n";
-import { SunIcon, MoonIcon, MonitorIcon, MicIcon, ShieldIcon } from "../../../shared/icons";
+import { SunIcon, MoonIcon, MonitorIcon, MicIcon, ShieldIcon, ChevronDownIcon } from "../../../shared/icons";
 import type { ThemeMode, SupportedLanguage } from "../../../shared/config";
 import { CustomSelect, type SelectItem } from "../ui/CustomSelect";
 import { OfflineBanner } from "../ui/OfflineBanner";
@@ -214,11 +214,14 @@ export function GeneralPanel() {
         </div>
       </div>
 
-      <div className={card.card}>
-        <div className={card.header}>
-          <h2>{t("general.recordingFeedback.title")}</h2>
-          <p className={card.description}>{t("general.recordingFeedback.description")}</p>
-        </div>
+      <details className={card.collapsible}>
+        <summary className={card.collapsibleHeader}>
+          <div>
+            <h2>{t("general.recordingFeedback.title")}</h2>
+            <p className={card.description}>{t("general.recordingFeedback.description")}</p>
+          </div>
+          <ChevronDownIcon width={16} height={16} className={card.chevron} />
+        </summary>
         <div className={card.body}>
           <div className={styles.fieldRow}>
             <label htmlFor="recording-start-sound">{t("general.recordingFeedback.startSound")}</label>
@@ -251,7 +254,7 @@ export function GeneralPanel() {
             />
           </div>
         </div>
-      </div>
+      </details>
 
       <div className={card.card}>
         <div className={card.header}>

--- a/src/renderer/components/layout/Titlebar.module.scss
+++ b/src/renderer/components/layout/Titlebar.module.scss
@@ -85,6 +85,42 @@
   white-space: nowrap;
 }
 
+.overrideBadgeGroup {
+  -webkit-app-region: no-drag;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+
+  &:hover .overrideClear {
+    width: 22px;
+    opacity: 1;
+    margin-right: 4px;
+  }
+}
+
+.overrideClear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 0;
+  height: 22px;
+  padding: 0;
+  background: #dc2626;
+  border: none;
+  border-radius: var(--radius-md);
+  color: white;
+  cursor: pointer;
+  opacity: 0;
+  overflow: hidden;
+  margin-right: 0;
+  flex-shrink: 0;
+  transition: width 150ms ease, opacity 150ms ease, margin-right 150ms ease;
+
+  &:hover {
+    background: #b91c1c;
+  }
+}
+
 .overrideBadge {
   -webkit-app-region: no-drag;
   display: flex;

--- a/src/renderer/components/shared/card.module.scss
+++ b/src/renderer/components/shared/card.module.scss
@@ -96,6 +96,43 @@
   }
 }
 
+.collapsible {
+  composes: card;
+
+  summary {
+    list-style: none;
+    cursor: pointer;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+}
+
+.collapsibleHeader {
+  composes: header;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+  padding-bottom: var(--spacing-5);
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.chevron {
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+  transition: transform 200ms ease;
+
+  details[open] > summary & {
+    transform: rotate(180deg);
+  }
+}
+
 .infoBannerLink {
   background: none;
   border: none;

--- a/src/renderer/components/transcriptions/TranscriptionsPanel.tsx
+++ b/src/renderer/components/transcriptions/TranscriptionsPanel.tsx
@@ -7,8 +7,10 @@ import {
   CheckIcon,
   CopyIcon,
   TrashAltIcon,
+  ChevronsLeftIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ChevronsRightIcon,
 } from "../../../shared/icons";
 import { CustomSelect } from "../ui/CustomSelect";
 import card from "../shared/card.module.scss";
@@ -204,12 +206,22 @@ export function TranscriptionsPanel() {
                 {page} / {totalPages || 1}
               </div>
               <div className={styles.pageControls}>
+                {page > 2 && (
+                  <button onClick={() => setPage(1)}>
+                    <ChevronsLeftIcon width={12} height={12} />
+                  </button>
+                )}
                 <button disabled={page <= 1} onClick={() => setPage(page - 1)}>
                   <ChevronLeftIcon width={12} height={12} />
                 </button>
                 <button disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
                   <ChevronRightIcon width={12} height={12} />
                 </button>
+                {page < totalPages - 1 && (
+                  <button onClick={() => setPage(totalPages)}>
+                    <ChevronsRightIcon width={12} height={12} />
+                  </button>
+                )}
               </div>
               {/* eslint-disable i18next/no-literal-string */}
               <div className={styles.pageSizeSelect}>

--- a/src/shared/icons/index.ts
+++ b/src/shared/icons/index.ts
@@ -29,6 +29,8 @@ export { default as ChevronLeftIcon } from "./svg/chevron-left.svg?react";
 export { default as ChevronRightIcon } from "./svg/chevron-right.svg?react";
 export { default as ChevronUpIcon } from "./svg/chevron-up.svg?react";
 export { default as ChevronDownIcon } from "./svg/chevron-down.svg?react";
+export { default as ChevronsLeftIcon } from "./svg/chevrons-left.svg?react";
+export { default as ChevronsRightIcon } from "./svg/chevrons-right.svg?react";
 export { default as EyeIcon } from "./svg/eye.svg?react";
 export { default as LockIcon } from "./svg/lock.svg?react";
 export { default as RecordIcon } from "./svg/record.svg?react";

--- a/src/shared/icons/svg/chevrons-left.svg
+++ b/src/shared/icons/svg/chevrons-left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="11 18 5 12 11 6"/>
+  <polyline points="18 18 12 12 18 6"/>
+</svg>

--- a/src/shared/icons/svg/chevrons-right.svg
+++ b/src/shared/icons/svg/chevrons-right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="13 18 19 12 13 6"/>
+  <polyline points="6 18 12 12 6 6"/>
+</svg>


### PR DESCRIPTION
## Summary

- Fix download progress bar X button breaking to a new line in the About panel by wrapping progress bar + dismiss in a flex row
- Improve Dictionary LLM warning banner with `InfoCircleIcon` and a proper `<button>` link (matching info banner pattern)
- Fix Dictionary dev override for `llmConnectionTested` so the Dev Panel correctly simulates the "not tested" state
- Convert Recording Feedback card to a collapsible `<details>`/`<summary>` element, collapsed by default
- Add a dismiss X button to the dev overrides badge that slides in on hover (clears all overrides)
- Reorder DevPanel grid to place LLM card next to Setup & Connectivity for better grouping
- Add first/last page buttons (double-chevron icons) to Dictionary and Transcriptions pagination

## Changes

- `AboutPanel.tsx` / `AboutPanel.module.scss` — flex row wrapper for progress bar + X button
- `DictionaryPanel.tsx` — icon + button link on LLM warning, `useDevOverrideValue` for `llmConnectionTested`, first/last pagination buttons
- `GeneralPanel.tsx` — collapsible Recording Feedback via `<details>`/`<summary>`
- `DevOverrideBadge.tsx` — dismiss X with slide-in animation
- `DevPanel.tsx` — reorder LLM card next to Setup & Connectivity
- `Titlebar.module.scss` — `.overrideBadgeGroup` and `.overrideClear` styles
- `card.module.scss` — `.collapsible`, `.collapsibleHeader`, `.chevron` reusable styles
- `TranscriptionsPanel.tsx` — first/last pagination buttons
- `icons/index.ts` — export `ChevronsLeftIcon`, `ChevronsRightIcon`
- New SVGs: `chevrons-left.svg`, `chevrons-right.svg`

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] Manually tested: About panel download progress bar stays in a single row
- [ ] Manually tested: Dictionary LLM warning shows icon and navigates to AI Enhancement tab
- [ ] Manually tested: Dev override for `llmConnectionTested` toggles warning correctly
- [ ] Manually tested: Recording Feedback collapses/expands with chevron rotation
- [ ] Manually tested: Dev overrides badge shows X on hover that clears all overrides
- [ ] Manually tested: First/last page buttons appear conditionally in pagination

## Code standards

- [x] **i18n** — All user-facing strings use the translation system. No new hardcoded strings.
- [x] **Dev Panel** — LLM card repositioned for better grouping; `llmConnectionTested` override wired up.
- [x] **CSS** — CSS Modules with custom properties. No hardcoded color/spacing values.
- [x] **SVGs** — New chevrons SVGs in separate files, exported via `icons/index.ts`.
- [x] **Accessibility** — Dismiss buttons have `aria-label`; collapsible uses native `<details>`/`<summary>`.