### PR TITLE
chore(make): add npm install to run and dev targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ uninstall:
 	rm -rf /Applications/Vox.app
 
 run:
+	npm install
 	npm run start
 
 dev:
+	npm install
 	npm run dev


### PR DESCRIPTION
## Summary
- Add `npm install` step before `npm run start` in the `run` Makefile target
- Add `npm install` step before `npm run dev` in the `dev` Makefile target
- Ensures dependencies are always up-to-date before starting the app

## Test plan
- [ ] Run `make run` and verify `npm install` executes before `npm run start`
- [ ] Run `make dev` and verify `npm install` executes before `npm run dev`
- [ ] Verify app starts correctly in both modes