### PR TITLE
fix(analytics): integrate dev override into override system and guard event

### DIFF
--- a/src/main/pipeline.ts
+++ b/src/main/pipeline.ts
@@ -238,9 +238,9 @@ export class Pipeline {
       });
     }
 
-    this.deps.analytics?.track("custom_prompt_used", {
-      has_prompt: Boolean(this.deps.hasCustomPrompt),
-    });
+    if (this.deps.hasCustomPrompt) {
+      this.deps.analytics?.track("custom_prompt_used");
+    }
 
     const llmStartTime = performance.now();
     const llmProviderName = this.deps.llmProvider.constructor.name.replace("Provider", "").toLowerCase();

--- a/src/renderer/components/dev/DevPanel.tsx
+++ b/src/renderer/components/dev/DevPanel.tsx
@@ -225,7 +225,6 @@ export function DevPanel() {
   const [systemLocale, setSystemLocale] = useState("");
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
   const [search, setSearch] = useState("");
-  const [analyticsDevEnabled, setAnalyticsDevEnabled] = useState(false);
 
   const fetchRuntime = useCallback(async () => {
     try {
@@ -306,6 +305,12 @@ export function DevPanel() {
 
   const ov = overrides.enabled;
   const ovProps = { overrides, setOverride, clearOverride };
+
+  // Sync analytics override to the main process
+  const analyticsOverride = ov ? overrides.analyticsDevEnabled : undefined;
+  useEffect(() => {
+    void window.voxApi.dev.setAnalyticsEnabled(analyticsOverride === true);
+  }, [analyticsOverride]);
 
   const isPresetActive = (preset: Partial<DevOverrides>) =>
     ov && Object.entries(preset).every(([key, value]) =>
@@ -501,23 +506,17 @@ export function DevPanel() {
     },
     {
       title: "Analytics",
+      overrideFields: ["analyticsDevEnabled"],
       rows: [
         { label: "Config Enabled", render: () => <>{boolDot(config?.analyticsEnabled)}</> },
         {
           label: "Send in Dev",
+          overrideField: "analyticsDevEnabled",
           render: () => (
-            <label className={styles.inlineToggle}>
-              <input
-                type="checkbox"
-                checked={analyticsDevEnabled}
-                onChange={async (e) => {
-                  const val = e.target.checked;
-                  await window.voxApi.dev.setAnalyticsEnabled(val);
-                  setAnalyticsDevEnabled(val);
-                }}
-              />
-              <span>{analyticsDevEnabled ? "on" : "off"}</span>
-            </label>
+            <>
+              <span className={styles.realValue}>{boolDot(false)}</span>
+              {ov && <OverrideBool field="analyticsDevEnabled" {...ovProps} />}
+            </>
           ),
         },
       ],
@@ -602,7 +601,7 @@ export function DevPanel() {
       models, systemLocale, systemInfo, ov, overrides, transcriptionTotal, transcriptionSearch,
       activeTab, collapsed, llmProvider, llmEnhancement, llmConnectionTested,
       llmConfigHash, currentHash, hashMatch, hasApiKey, modelName, selectedModel,
-      downloadedModels, analyticsDevEnabled]);
+      downloadedModels]);
 
   const q = search.trim().toLowerCase();
 

--- a/src/renderer/stores/dev-overrides-store.ts
+++ b/src/renderer/stores/dev-overrides-store.ts
@@ -12,6 +12,7 @@ export interface DevOverrides {
   online?: boolean;
   llmEnhancementEnabled?: boolean;
   llmConnectionTested?: boolean;
+  analyticsDevEnabled?: boolean;
   hideDevVisuals?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- **Dev Panel override indicators**: The Analytics "Send in Dev" toggle was operating outside the `DevOverrides` system — toggling it showed no purple dot, card border, titlebar badge, or sidebar label. Integrated it into the same store so it gets persistence to localStorage, responds to "Clear All" and the master toggle, and shows all standard override indicators. A `useEffect` syncs the value to the main process via IPC.
- **Guard `custom_prompt_used` event**: The analytics event was being fired unconditionally on every pipeline run, even when no custom prompt was configured. Now only tracked when `hasCustomPrompt` is true, matching the `dictionary_used` pattern.

## Test plan
- [x] Open Dev Panel, enable "Override States", set Analytics → Send in Dev to `true` — verify purple dot appears on the row, card gets purple border, and "Overrides Active" badge shows in titlebar
- [x] Click "Clear All" — verify analytics override is cleared and `setAnalyticsEnabled(false)` is called
- [x] Toggle master "Override States" off — verify analytics reverts to disabled
- [x] Reload the app — verify analytics override persists via localStorage
- [x] Run pipeline with empty custom prompt — verify `custom_prompt_used` event is NOT fired
- [x] Run pipeline with a custom prompt set — verify `custom_prompt_used` event IS fired