### PR TITLE
fix(mac): ensure app stays visible in dock and Cmd+Tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
-        "LSUIElement": false,
         "NSMicrophoneUsageDescription": "Vox needs microphone access to record your voice for transcription.",
         "NSAccessibilityUsageDescription": "Vox needs accessibility access to paste transcribed text automatically."
       }

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -110,6 +110,8 @@ function reloadConfig(): void {
 }
 
 app.whenReady().then(async () => {
+  app.dock?.show();
+
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
     callback(permission === "media");
   });
@@ -249,8 +251,7 @@ app.whenReady().then(async () => {
   openHome(reloadConfig);
 });
 
-app.on("activate", (_event, hasVisibleWindows) => {
-  if (hasVisibleWindows) return;
+app.on("activate", () => {
   openHome(reloadConfig);
 });
 


### PR DESCRIPTION
## Summary

- Removes `LSUIElement: false` from `extendInfo` in `package.json` — the mere **presence** of this key in the plist causes macOS Launch Services to flag the app as a UI-element/accessory, hiding it from the dock and Cmd+Tab app switcher. The default (key absent) is "regular app"
- Adds `app.dock.show()` at startup as a safety net against stale Launch Services cache entries from older builds that had `LSUIElement: true`

## Root cause

The app was built with `LSUIElement: true` in early versions (pre-0.2.0). When changed to `false`, two issues remained:

1. macOS Launch Services caches app metadata and doesn't always re-read the Info.plist — users who had older versions still had the `ui-element` flag cached
2. Even with `false`, the **presence** of the `LSUIElement` key in the plist can cause Launch Services to set the `ui-element` bundle flag (confirmed via `lsregister -dump` showing `bundle flags: ui-element` despite `LSUIElement => 0`)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (235/235)
- [x] Build the app and verify `LSUIElement` key is NOT present in `Info.plist`
- [x] Install and verify app appears in dock
- [x] Switch to another app and verify Vox stays in Cmd+Tab
- [x] Close settings window (Cmd+W) and verify Vox stays in dock + Cmd+Tab
- [x] Restart app and verify dock icon appears immediately

Needs https://github.com/app-vox/vox/pull/202