### PR TITLE
fix(analytics): await shutdown before quitting to flush app_quit event

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -261,11 +261,16 @@ app.on("before-quit", () => {
   }
 });
 
-app.on("will-quit", () => {
-  analytics.track("app_quit", {
-    session_duration_ms: Math.round(performance.now()),
-  });
-  analytics.shutdown();
+let isQuitting = false;
+app.on("will-quit", (event) => {
+  if (!isQuitting) {
+    isQuitting = true;
+    event.preventDefault();
+    analytics.track("app_quit", {
+      session_duration_ms: Math.round(performance.now()),
+    });
+    analytics.shutdown().finally(() => app.quit());
+  }
 });
 
 app.on("window-all-closed", () => {});


### PR DESCRIPTION
## Summary

- Fix `app_quit` events never reaching PostHog because the process exits before `analytics.shutdown()` flushes pending events
- Use `event.preventDefault()` in `will-quit` to delay exit, flush analytics, then call `app.quit()` to resume shutdown
- Guard with `isQuitting` flag to prevent infinite recursion

## Test plan

- [x] 216 tests passing (19 pre-existing renderer failures unrelated to this change)
- [x] TypeScript compiles cleanly
- [ ] Verify `app_quit` events appear in PostHog after quitting the app

Closes #183