### PR TITLE
fix(landing): move stop icon to right side of pill during listening

### DIFF
--- a/style.css
+++ b/style.css
@@ -584,6 +584,7 @@ body {
     display: flex;
     align-items: center;
     flex-shrink: 0;
+    order: 1;
 }
 
 .hud-bars {


### PR DESCRIPTION
## Summary

- Adds `order: 1` to `.hud-stop-icon` so the stop button renders on the right side of the pill during the equalizer/listening animation.

## Test plan

- [x] Verify stop icon appears on the right side of the HUD pill during recording animation