### PR TITLE
test(coverage): add tests for untested LLM providers, audio cues, and pipeline logic

### DIFF
--- a/tests/main/llm/anthropic.test.ts
+++ b/tests/main/llm/anthropic.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron-log/main", () => ({
+  default: {
+    scope: vi.fn().mockReturnValue({
+      info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    }),
+  },
+}));
+
+import { AnthropicProvider } from "../../../src/main/llm/anthropic";
+import { type LlmProvider } from "../../../src/main/llm/provider";
+import { LLM_SYSTEM_PROMPT } from "../../../src/shared/constants";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("AnthropicProvider", () => {
+  let provider: LlmProvider;
+
+  beforeEach(() => {
+    provider = new AnthropicProvider({
+      apiKey: "sk-ant-test-key",
+      model: "claude-sonnet-4-20250514",
+      customPrompt: LLM_SYSTEM_PROMPT,
+      hasCustomPrompt: false,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("should return corrected text from Anthropic API", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "I wanted to talk about the new feature." }],
+      }),
+    });
+
+    const result = await provider.correct("so um I wanted to talk about the uh new feature");
+
+    expect(result).toBe("I wanted to talk about the new feature.");
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it("should throw on HTTP error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: async () => "Invalid API key",
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM request failed: 401 Unauthorized");
+  });
+
+  it("should throw when response has no text block", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "tool_use", text: "" }],
+      }),
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM returned no text content");
+  });
+
+  it("should call the Anthropic messages endpoint", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "result" }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  it("should send x-api-key and anthropic-version headers", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "result" }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["x-api-key"]).toBe("sk-ant-test-key");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("should send the system prompt and user text in the request body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "cleaned text" }],
+      }),
+    });
+
+    await provider.correct("raw text");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.system).toBe(LLM_SYSTEM_PROMPT);
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[0].content).toBe("raw text");
+    expect(body.model).toBe("claude-sonnet-4-20250514");
+    expect(body.temperature).toBe(0.1);
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  it("should trim whitespace from response text", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "  trimmed result  " }],
+      }),
+    });
+
+    const result = await provider.correct("test");
+    expect(result).toBe("trimmed result");
+  });
+});

--- a/tests/main/llm/custom.test.ts
+++ b/tests/main/llm/custom.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron-log/main", () => ({
+  default: {
+    scope: vi.fn().mockReturnValue({
+      info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    }),
+  },
+}));
+
+import { CustomProvider } from "../../../src/main/llm/custom";
+import { type LlmProvider } from "../../../src/main/llm/provider";
+import { LLM_SYSTEM_PROMPT } from "../../../src/shared/constants";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function createProvider(overrides: Partial<ConstructorParameters<typeof CustomProvider>[0]> = {}): LlmProvider {
+  return new CustomProvider({
+    endpoint: "https://my-llm.example.com/api/chat",
+    token: "my-secret-token",
+    tokenAttr: "Authorization",
+    tokenSendAs: "header",
+    model: "custom-model",
+    customPrompt: LLM_SYSTEM_PROMPT,
+    hasCustomPrompt: false,
+    ...overrides,
+  });
+}
+
+describe("CustomProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return corrected text from the API", async () => {
+    const provider = createProvider();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "Corrected text." } }],
+      }),
+    });
+
+    const result = await provider.correct("raw text");
+
+    expect(result).toBe("Corrected text.");
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it("should throw on HTTP error", async () => {
+    const provider = createProvider();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "Server error",
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM request failed: 500 Internal Server Error");
+  });
+
+  it("should throw when response has no content", async () => {
+    const provider = createProvider();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ choices: [] }),
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM returned no text content");
+  });
+
+  describe("token send modes", () => {
+    it("should send token as header when tokenSendAs is 'header'", async () => {
+      const provider = createProvider({
+        tokenSendAs: "header",
+        tokenAttr: "X-API-Key",
+        token: "header-token",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "result" } }],
+        }),
+      });
+
+      await provider.correct("test");
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers["X-API-Key"]).toBe("header-token");
+    });
+
+    it("should send token in request body when tokenSendAs is 'body'", async () => {
+      const provider = createProvider({
+        tokenSendAs: "body",
+        tokenAttr: "api_key",
+        token: "body-token",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "result" } }],
+        }),
+      });
+
+      await provider.correct("test");
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.api_key).toBe("body-token");
+    });
+
+    it("should send token as query parameter when tokenSendAs is 'query'", async () => {
+      const provider = createProvider({
+        endpoint: "https://my-llm.example.com/api/chat",
+        tokenSendAs: "query",
+        tokenAttr: "key",
+        token: "query-token",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "result" } }],
+        }),
+      });
+
+      await provider.correct("test");
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe("https://my-llm.example.com/api/chat?key=query-token");
+    });
+
+    it("should append query param with & when URL already has query string", async () => {
+      const provider = createProvider({
+        endpoint: "https://my-llm.example.com/api/chat?version=2",
+        tokenSendAs: "query",
+        tokenAttr: "key",
+        token: "query-token",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "result" } }],
+        }),
+      });
+
+      await provider.correct("test");
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe("https://my-llm.example.com/api/chat?version=2&key=query-token");
+    });
+
+    it("should URL-encode query parameter name and value", async () => {
+      const provider = createProvider({
+        endpoint: "https://my-llm.example.com/api",
+        tokenSendAs: "query",
+        tokenAttr: "api key",
+        token: "tok&en=val",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "result" } }],
+        }),
+      });
+
+      await provider.correct("test");
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain("api%20key=tok%26en%3Dval");
+    });
+
+    it("should not send token when token or tokenAttr is empty", async () => {
+      const provider = createProvider({
+        token: "",
+        tokenAttr: "Authorization",
+        tokenSendAs: "header",
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "result" } }],
+        }),
+      });
+
+      await provider.correct("test");
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+  });
+
+  it("should strip trailing slashes from endpoint", async () => {
+    const provider = createProvider({
+      endpoint: "https://my-llm.example.com/api///",
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "result" } }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toBe("https://my-llm.example.com/api");
+  });
+
+  it("should include model in body when provided", async () => {
+    const provider = createProvider({ model: "my-model-v2" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "result" } }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.model).toBe("my-model-v2");
+  });
+
+  it("should omit model from body when empty", async () => {
+    const provider = createProvider({ model: "" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "result" } }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.model).toBeUndefined();
+  });
+
+  it("should send system and user messages", async () => {
+    const provider = createProvider();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "cleaned" } }],
+      }),
+    });
+
+    await provider.correct("raw text");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.messages).toEqual([
+      { role: "system", content: LLM_SYSTEM_PROMPT },
+      { role: "user", content: "raw text" },
+    ]);
+  });
+});

--- a/tests/main/llm/openai-compatible.test.ts
+++ b/tests/main/llm/openai-compatible.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron-log/main", () => ({
+  default: {
+    scope: vi.fn().mockReturnValue({
+      info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    }),
+  },
+}));
+
+import { OpenAICompatibleProvider } from "../../../src/main/llm/openai-compatible";
+import { type LlmProvider } from "../../../src/main/llm/provider";
+import { LLM_SYSTEM_PROMPT } from "../../../src/shared/constants";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("OpenAICompatibleProvider", () => {
+  let provider: LlmProvider;
+
+  beforeEach(() => {
+    provider = new OpenAICompatibleProvider({
+      endpoint: "https://api.openai.com",
+      apiKey: "sk-test-key",
+      model: "gpt-4o",
+      customPrompt: LLM_SYSTEM_PROMPT,
+      hasCustomPrompt: false,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("should return corrected text from the API", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "I wanted to talk about the new feature." } }],
+      }),
+    });
+
+    const result = await provider.correct("so um I wanted to talk about the uh new feature");
+
+    expect(result).toBe("I wanted to talk about the new feature.");
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it("should throw on HTTP error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      text: async () => "Rate limit exceeded",
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM request failed: 429 Too Many Requests");
+  });
+
+  it("should throw when response has no content", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "" } }],
+      }),
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM returned no text content");
+  });
+
+  it("should throw when choices array is empty", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ choices: [] }),
+    });
+
+    await expect(provider.correct("test")).rejects.toThrow("LLM returned no text content");
+  });
+
+  it("should append /v1/chat/completions to the endpoint", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "result" } }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("should strip trailing slashes from endpoint before appending path", async () => {
+    const providerWithSlash = new OpenAICompatibleProvider({
+      endpoint: "https://api.openai.com///",
+      apiKey: "key",
+      model: "gpt-4o",
+      customPrompt: LLM_SYSTEM_PROMPT,
+      hasCustomPrompt: false,
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "result" } }],
+      }),
+    });
+
+    await providerWithSlash.correct("test");
+
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("should send Bearer token in Authorization header", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "result" } }],
+      }),
+    });
+
+    await provider.correct("test");
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["Authorization"]).toBe("Bearer sk-test-key");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("should send system and user messages in request body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "cleaned" } }],
+      }),
+    });
+
+    await provider.correct("raw text");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.messages).toEqual([
+      { role: "system", content: LLM_SYSTEM_PROMPT },
+      { role: "user", content: "raw text" },
+    ]);
+    expect(body.model).toBe("gpt-4o");
+    expect(body.temperature).toBe(0.1);
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  it("should trim whitespace from response content", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "  trimmed  " } }],
+      }),
+    });
+
+    const result = await provider.correct("test");
+    expect(result).toBe("trimmed");
+  });
+});

--- a/tests/main/pipeline-garbage.test.ts
+++ b/tests/main/pipeline-garbage.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Pipeline } from "../../src/main/pipeline";
+import { type LlmProvider } from "../../src/main/llm/provider";
+
+vi.mock("electron-log/main", () => ({
+  default: {
+    scope: vi.fn().mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+/**
+ * Tests for the garbage/hallucination detection logic in Pipeline.
+ *
+ * Whisper commonly hallucinates phrases when fed silence or background noise.
+ * The pipeline filters these out before sending to the LLM provider.
+ * These tests ensure the filter works correctly without being coupled to
+ * implementation details — they test through the public stopAndProcess API.
+ */
+describe("Pipeline garbage/hallucination detection", () => {
+  const mockProvider: LlmProvider = {
+    correct: vi.fn().mockResolvedValue("corrected"),
+  };
+
+  function createPipeline(transcriptionText: string) {
+    return new Pipeline({
+      recorder: {
+        start: vi.fn(),
+        stop: vi.fn().mockResolvedValue({
+          audioBuffer: new Float32Array([0.1, 0.2, 0.3]),
+          sampleRate: 16000,
+        }),
+      },
+      transcribe: vi.fn().mockResolvedValue({ text: transcriptionText }),
+      llmProvider: mockProvider,
+      modelPath: "/models/ggml-small.bin",
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("common Whisper hallucinations", () => {
+    it.each([
+      "thank you",
+      "thanks for watching",
+      "bye",
+      "subscribe",
+      "like and subscribe",
+      "thank you so much",
+      "the end",
+      "...",
+      "ok",
+      "yeah",
+      "um",
+      "uh",
+    ])("should reject known hallucination: %j", async (hallucination) => {
+      const pipeline = createPipeline(hallucination);
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+      expect(mockProvider.correct).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("short text rejection", () => {
+    it("should reject very short transcriptions (< 5 chars)", async () => {
+      const pipeline = createPipeline("hi");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+      expect(mockProvider.correct).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("bracketed sound descriptions", () => {
+    it("should reject text that is only bracketed descriptions", async () => {
+      const pipeline = createPipeline("[BLANK_AUDIO]");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+    });
+
+    it("should reject text that is only parenthesized descriptions", async () => {
+      const pipeline = createPipeline("(machine whirring)");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+    });
+
+    it("should reject text that is only asterisk descriptions", async () => {
+      const pipeline = createPipeline("*music playing*");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+    });
+  });
+
+  describe("repetitive character detection", () => {
+    it("should reject text with a single character making up >50% of content", async () => {
+      const pipeline = createPipeline("aaaaaaaab");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+    });
+
+    it("should reject long text with very low character diversity", async () => {
+      // 20+ chars but only 2 distinct characters
+      const pipeline = createPipeline("ababababababababababab");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+    });
+  });
+
+  describe("valid transcriptions should pass", () => {
+    it("should allow normal speech through to LLM", async () => {
+      const pipeline = createPipeline("I need to schedule a meeting for tomorrow");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("corrected");
+      expect(mockProvider.correct).toHaveBeenCalledWith("I need to schedule a meeting for tomorrow");
+    });
+
+    it("should allow short but valid sentences", async () => {
+      const pipeline = createPipeline("Hello world test");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("corrected");
+      expect(mockProvider.correct).toHaveBeenCalled();
+    });
+
+    it("should allow text with mixed brackets and real content", async () => {
+      const pipeline = createPipeline("(laughing) That was really funny and I loved it");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("corrected");
+    });
+  });
+
+  describe("empty transcription", () => {
+    it("should return empty string for empty transcription", async () => {
+      const pipeline = createPipeline("");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+      expect(mockProvider.correct).not.toHaveBeenCalled();
+    });
+
+    it("should return empty string for whitespace-only transcription", async () => {
+      const pipeline = createPipeline("   ");
+      await pipeline.startRecording();
+      const result = await pipeline.stopAndProcess();
+
+      expect(result).toBe("");
+    });
+  });
+});

--- a/tests/renderer/stores/permissions-store.test.ts
+++ b/tests/renderer/stores/permissions-store.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { installVoxApiMock, resetStores } from "../helpers/setup";
+import { usePermissionsStore } from "../../../src/renderer/stores/permissions-store";
+import type { VoxAPI } from "../../../src/preload/index";
+
+let mockApi: VoxAPI;
+
+beforeEach(() => {
+  mockApi = installVoxApiMock();
+  resetStores();
+});
+
+describe("usePermissionsStore", () => {
+  it("should start with null status and keychainStatus", () => {
+    const state = usePermissionsStore.getState();
+    expect(state.status).toBeNull();
+    expect(state.keychainStatus).toBeNull();
+  });
+
+  describe("refresh", () => {
+    it("should fetch and set permissions status and keychain status", async () => {
+      const permStatus = { microphone: "granted" as const, accessibility: true, pid: 123, execPath: "/app", bundleId: "com.test" };
+      const keychainStatus = { available: true, encryptedCount: 3 };
+
+      vi.mocked(mockApi.permissions.status).mockResolvedValue(permStatus);
+      vi.mocked(mockApi.permissions.keychainStatus).mockResolvedValue(keychainStatus);
+
+      await usePermissionsStore.getState().refresh();
+
+      const state = usePermissionsStore.getState();
+      expect(state.status).toEqual(permStatus);
+      expect(state.keychainStatus).toEqual(keychainStatus);
+    });
+
+    it("should call both status and keychainStatus APIs", async () => {
+      await usePermissionsStore.getState().refresh();
+
+      expect(mockApi.permissions.status).toHaveBeenCalledOnce();
+      expect(mockApi.permissions.keychainStatus).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("requestMicrophone", () => {
+    it("should call requestMicrophone API and then refresh", async () => {
+      const permStatus = { microphone: "granted" as const, accessibility: true, pid: 1, execPath: "", bundleId: "" };
+      vi.mocked(mockApi.permissions.status).mockResolvedValue(permStatus);
+
+      await usePermissionsStore.getState().requestMicrophone();
+
+      expect(mockApi.permissions.requestMicrophone).toHaveBeenCalledOnce();
+      // Should also refresh status after requesting
+      expect(mockApi.permissions.status).toHaveBeenCalled();
+      expect(mockApi.permissions.keychainStatus).toHaveBeenCalled();
+    });
+  });
+
+  describe("requestAccessibility", () => {
+    it("should call requestAccessibility API", async () => {
+      await usePermissionsStore.getState().requestAccessibility();
+
+      expect(mockApi.permissions.requestAccessibility).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/tests/shared/audio-cue.test.ts
+++ b/tests/shared/audio-cue.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { isWavCue, getWavFilename, parseWavSamples, generateCueSamples } from "../../src/shared/audio-cue";
+import type { AudioCueType } from "../../src/shared/config";
+
+describe("isWavCue", () => {
+  it.each<[AudioCueType, boolean]>([
+    ["tap", true],
+    ["tick", true],
+    ["pop", true],
+    ["ping", true],
+    ["ding", true],
+    ["nudge", true],
+    ["error", true],
+    ["click", false],
+    ["beep", false],
+    ["chime", false],
+    ["none", false],
+  ])("isWavCue(%j) should return %s", (type, expected) => {
+    expect(isWavCue(type)).toBe(expected);
+  });
+});
+
+describe("getWavFilename", () => {
+  it.each<[AudioCueType, string | null]>([
+    ["tap", "tap.wav"],
+    ["tick", "tick.wav"],
+    ["pop", "pop.wav"],
+    ["ping", "ping.wav"],
+    ["ding", "ding.wav"],
+    ["nudge", "nudge.wav"],
+    ["error", "error.wav"],
+    ["click", null],
+    ["beep", null],
+    ["chime", null],
+    ["none", null],
+  ])("getWavFilename(%j) should return %j", (type, expected) => {
+    expect(getWavFilename(type)).toBe(expected);
+  });
+});
+
+describe("parseWavSamples", () => {
+  function buildWavBuffer(opts: {
+    channels?: number;
+    sampleRate?: number;
+    bitsPerSample?: number;
+    samples: number[];
+  }): Buffer {
+    const channels = opts.channels ?? 1;
+    const sampleRate = opts.sampleRate ?? 44100;
+    const bitsPerSample = opts.bitsPerSample ?? 16;
+    const bytesPerSample = bitsPerSample / 8;
+    const dataSize = opts.samples.length * bytesPerSample;
+
+    // RIFF header (12) + fmt chunk (24) + data chunk header (8) + data
+    const totalSize = 12 + 24 + 8 + dataSize;
+    const buf = Buffer.alloc(totalSize);
+
+    // RIFF header
+    buf.write("RIFF", 0);
+    buf.writeUInt32LE(totalSize - 8, 4);
+    buf.write("WAVE", 8);
+
+    // fmt chunk
+    buf.write("fmt ", 12);
+    buf.writeUInt32LE(16, 16); // chunk size
+    buf.writeUInt16LE(1, 20); // PCM format
+    buf.writeUInt16LE(channels, 22);
+    buf.writeUInt32LE(sampleRate, 24);
+    buf.writeUInt32LE(sampleRate * channels * bytesPerSample, 28); // byte rate
+    buf.writeUInt16LE(channels * bytesPerSample, 32); // block align
+    buf.writeUInt16LE(bitsPerSample, 34);
+
+    // data chunk
+    buf.write("data", 36);
+    buf.writeUInt32LE(dataSize, 40);
+    for (let i = 0; i < opts.samples.length; i++) {
+      buf.writeInt16LE(opts.samples[i], 44 + i * bytesPerSample);
+    }
+
+    return buf;
+  }
+
+  it("should parse a mono 16-bit WAV with known samples", () => {
+    // 16384 / 32768 = 0.5, -16384 / 32768 = -0.5
+    const wavBuf = buildWavBuffer({ samples: [16384, -16384, 0] });
+    const result = parseWavSamples(wavBuf);
+
+    expect(result.sampleRate).toBe(44100);
+    expect(result.samples).toHaveLength(3);
+    expect(result.samples[0]).toBeCloseTo(0.5, 4);
+    expect(result.samples[1]).toBeCloseTo(-0.5, 4);
+    expect(result.samples[2]).toBeCloseTo(0, 4);
+  });
+
+  it("should parse a stereo WAV and average channels to mono", () => {
+    // stereo: L=32767, R=0 → avg = (1.0 + 0.0) / 2 = 0.5
+    const wavBuf = buildWavBuffer({
+      channels: 2,
+      samples: [32767, 0], // one frame: left + right
+    });
+    const result = parseWavSamples(wavBuf);
+
+    expect(result.samples).toHaveLength(1);
+    expect(result.samples[0]).toBeCloseTo(0.5, 1);
+  });
+
+  it("should return empty samples for a buffer with no data chunk", () => {
+    // Just a RIFF header + fmt chunk, no data chunk
+    const buf = Buffer.alloc(36);
+    buf.write("RIFF", 0);
+    buf.writeUInt32LE(28, 4);
+    buf.write("WAVE", 8);
+    buf.write("fmt ", 12);
+    buf.writeUInt32LE(16, 16);
+    buf.writeUInt16LE(1, 20);
+    buf.writeUInt16LE(1, 22);
+    buf.writeUInt32LE(44100, 24);
+    buf.writeUInt32LE(88200, 28);
+    buf.writeUInt16LE(2, 32);
+    buf.writeUInt16LE(16, 34);
+
+    const result = parseWavSamples(buf);
+    expect(result.samples).toEqual([]);
+    expect(result.sampleRate).toBe(44100);
+  });
+
+  it("should read the sample rate from the fmt chunk", () => {
+    const wavBuf = buildWavBuffer({ sampleRate: 16000, samples: [0] });
+    const result = parseWavSamples(wavBuf);
+    expect(result.sampleRate).toBe(16000);
+  });
+});
+
+describe("generateCueSamples", () => {
+  it("should return empty array for 'none'", () => {
+    expect(generateCueSamples("none", 44100)).toEqual([]);
+  });
+
+  it("should generate samples within [-1, 1] range for click", () => {
+    const samples = generateCueSamples("click", 44100);
+    expect(samples.length).toBeGreaterThan(0);
+    for (const s of samples) {
+      expect(s).toBeGreaterThanOrEqual(-1);
+      expect(s).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("should generate samples within [-1, 1] range for beep", () => {
+    const samples = generateCueSamples("beep", 44100);
+    expect(samples.length).toBeGreaterThan(0);
+    for (const s of samples) {
+      expect(s).toBeGreaterThanOrEqual(-1);
+      expect(s).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("should generate samples within [-1, 1] range for chime", () => {
+    const samples = generateCueSamples("chime", 44100);
+    expect(samples.length).toBeGreaterThan(0);
+    for (const s of samples) {
+      expect(s).toBeGreaterThanOrEqual(-1);
+      expect(s).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("should return empty array for wav-based cue types", () => {
+    // wav-based cues like 'tap' are loaded from files, not generated
+    expect(generateCueSamples("tap", 44100)).toEqual([]);
+  });
+
+  it("should scale sample count with sample rate", () => {
+    const at44100 = generateCueSamples("beep", 44100);
+    const at22050 = generateCueSamples("beep", 22050);
+    // beep duration is 0.15s, so sample count should roughly halve
+    expect(at22050.length).toBeCloseTo(at44100.length / 2, -1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for **Anthropic**, **OpenAI-compatible**, and **Custom** LLM providers (all 0% → 100%)
- Add tests for `audio-cue.ts` utilities: `isWavCue`, `getWavFilename`, `parseWavSamples` (51% → 97%)
- Add tests for **permissions Zustand store** (0% → 100%)
- Add thorough tests for **pipeline garbage/hallucination detection** (23 scenarios covering known Whisper hallucinations, bracketed descriptions, repetitive chars, and valid passthrough)

**Coverage impact:** 20.3% → 23.14% statements, 20.93% → 23.85% lines (89 new tests, all deterministic).

Key module improvements:
| Module | Before | After |
|--------|--------|-------|
| main/llm | ~62% | 96.89% |
| shared | ~70% | 96.80% |
| renderer/stores | ~83% | 89.71% |

## Test plan
- [x] All 324 tests pass (`npx vitest run`)
- [x] No flaky tests — all deterministic with mocked I/O
- [x] Coverage verified with `npx vitest run --coverage`