### PR TITLE
feat(analytics): use PostHog captureException for error tracking

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -204,6 +204,10 @@ app.whenReady().then(async () => {
     return enabled;
   });
 
+  ipcMain.handle("dev:test-error", () => {
+    analytics.captureError(new Error("Test error from Dev Panel"), { scope: "devPanel" });
+  });
+
   ipcMain.handle("dev:get-system-info", () => {
     return {
       electronVersion: process.versions.electron,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -151,6 +151,7 @@ export interface VoxAPI {
       whisperLib: string;
     }>;
     setAnalyticsEnabled(enabled: boolean): Promise<boolean>;
+    testError(): Promise<void>;
   };
 }
 
@@ -255,6 +256,7 @@ const voxApi: VoxAPI = {
     getRuntimeState: () => ipcRenderer.invoke("dev:get-runtime-state"),
     getSystemInfo: () => ipcRenderer.invoke("dev:get-system-info"),
     setAnalyticsEnabled: (enabled: boolean) => ipcRenderer.invoke("dev:set-analytics-enabled", enabled),
+    testError: () => ipcRenderer.invoke("dev:test-error"),
   },
 };
 

--- a/src/renderer/components/dev/DevPanel.tsx
+++ b/src/renderer/components/dev/DevPanel.tsx
@@ -557,6 +557,14 @@ export function DevPanel() {
             </>
           ),
         },
+        {
+          label: "Test Error",
+          render: () => (
+            <button className={styles.setBtn} onClick={() => void window.voxApi.dev.testError()}>
+              Send
+            </button>
+          ),
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Replace manual `error_uncaught` custom events with PostHog's built-in `captureException()` method
- Errors now appear in PostHog's **Error Tracking** product with automatic grouping, stack trace visualization, and frequency analysis

## Test plan

- [x] 15 analytics service tests passing
- [x] TypeScript compiles cleanly
- [x] Trigger an error in dev mode and verify it appears in PostHog Error Tracking UI