### PR TITLE
fix(updater): ensure app actually restarts after update install

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -124,6 +124,6 @@ export function getUpdateState(): UpdateState {
 
 export function quitAndInstall(): void {
   if (app.isPackaged) {
-    autoUpdater.quitAndInstall();
+    autoUpdater.quitAndInstall(false, true);
   }
 }


### PR DESCRIPTION
## Summary

- Pass `isForceRunAfter=true` (second argument) to `autoUpdater.quitAndInstall()` so the app actually relaunches after installing an update
- Previously, clicking "Restart Now" would quit the app and install the update but never relaunch it, requiring users to manually reopen the app
- The first argument (`isSilent`) is set to `false` to preserve the default install behavior

## Test plan

- [x] Verify a new update is available (or mock one) and click "Restart Now"
- [x] Confirm the app quits, installs the update, and automatically relaunches
- [x] Confirm the app shows the updated version after relaunch