### PR TITLE
feat(onboarding): add analytics events, fix opening, and devpanel trigger

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -265,6 +265,7 @@ app.whenReady().then(async () => {
       shortcutManager?.updateHud();
       updateTrayConfig(cfg);
       refreshAppMenu();
+      openHome(reloadConfig);
       for (const win of BrowserWindow.getAllWindows()) {
         win.webContents.send("config:changed");
       }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -334,4 +334,8 @@ export function registerIpcHandlers(
   ipcMain.handle("i18n:system-locale", () => {
     return app.getLocale();
   });
+
+  ipcMain.handle("analytics:track", (_event, name: string, properties?: Record<string, unknown>) => {
+    analytics?.track(name, properties);
+  });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -154,6 +154,9 @@ export interface VoxAPI {
     setAnalyticsEnabled(enabled: boolean): Promise<boolean>;
     testError(): Promise<void>;
   };
+  analytics: {
+    track(event: string, properties?: Record<string, unknown>): Promise<void>;
+  };
 }
 
 const voxApi: VoxAPI = {
@@ -259,6 +262,10 @@ const voxApi: VoxAPI = {
     getSystemInfo: () => ipcRenderer.invoke("dev:get-system-info"),
     setAnalyticsEnabled: (enabled: boolean) => ipcRenderer.invoke("dev:set-analytics-enabled", enabled),
     testError: () => ipcRenderer.invoke("dev:test-error"),
+  },
+  analytics: {
+    track: (event: string, properties?: Record<string, unknown>) =>
+      ipcRenderer.invoke("analytics:track", event, properties),
   },
 };
 

--- a/src/renderer/components/dev/DevPanel.tsx
+++ b/src/renderer/components/dev/DevPanel.tsx
@@ -627,21 +627,20 @@ export function DevPanel() {
           render: () => (
             <>
               <span className={styles.realValue}>{boolDot(config?.onboardingCompleted)}</span>
-              {config?.onboardingCompleted && (
-                <button
-                  className={styles.setBtn}
-                  onClick={async () => {
-                    const { useOnboardingStore } = await import("../onboarding/use-onboarding-store");
-                    useOnboardingStore.getState().setForceOpen(true);
-                    const store = useConfigStore.getState();
-                    store.updateConfig({ onboardingCompleted: false });
-                    await store.saveConfig(false);
-                    triggerToast();
-                  }}
-                >
-                  Reset
-                </button>
-              )}
+              <button
+                className={styles.setBtn}
+                onClick={async () => {
+                  const { useOnboardingStore } = await import("../onboarding/use-onboarding-store");
+                  useOnboardingStore.getState().reset();
+                  useOnboardingStore.getState().setForceOpen(true);
+                  const store = useConfigStore.getState();
+                  store.updateConfig({ onboardingCompleted: false });
+                  await store.saveConfig(false);
+                  triggerToast();
+                }}
+              >
+                {config?.onboardingCompleted ? "Reset" : "Open"}
+              </button>
             </>
           ),
         },

--- a/src/renderer/components/general/GeneralPanel.tsx
+++ b/src/renderer/components/general/GeneralPanel.tsx
@@ -75,6 +75,7 @@ export function GeneralPanel() {
     ...(devAccOverride !== undefined ? { accessibility: devAccOverride } : {}),
   };
 
+  const onboardingOpen = useOnboardingStore((s) => s.forceOpen);
   const bannersReady = !loading && realStatus !== null;
   const needsSetup = !setupComplete || permissionStatus.microphone !== "granted" || permissionStatus.accessibility !== true;
 
@@ -323,7 +324,7 @@ export function GeneralPanel() {
       )}
 
       {/* Shortcuts discovery banner */}
-      {bannersReady && setupComplete && !shortcutsBannerDismissed && (devVisitedShortcuts === false || !config.onboardingCompleted) && (
+      {bannersReady && setupComplete && !shortcutsBannerDismissed && !onboardingOpen && (devVisitedShortcuts === false || !config.onboardingCompleted) && (
         <div className={`${card.card} ${styles.setupBanner}`}>
           <div className={card.body}>
             <div className={styles.hudBannerContent}>

--- a/tests/renderer/helpers/setup.ts
+++ b/tests/renderer/helpers/setup.ts
@@ -70,6 +70,7 @@ export function createVoxApiMock(): VoxAPI {
     history: {
       get: vi.fn().mockResolvedValue({ entries: [], total: 0 }),
       search: vi.fn().mockResolvedValue({ entries: [], total: 0 }),
+      add: vi.fn().mockResolvedValue(undefined),
       deleteEntry: vi.fn().mockResolvedValue(undefined),
       clear: vi.fn().mockResolvedValue(undefined),
       onEntryAdded: vi.fn(),
@@ -89,6 +90,9 @@ export function createVoxApiMock(): VoxAPI {
     dev: {
       getRuntimeState: vi.fn().mockResolvedValue({ shortcutState: "", isRecording: false, indicatorVisible: false, indicatorMode: null, isListening: false, hasModel: false, trayActive: false }),
       getSystemInfo: vi.fn().mockResolvedValue({ electronVersion: "", nodeVersion: "", chromeVersion: "", v8Version: "", platform: "", arch: "", isPackaged: false, appVersion: "", appPath: "", userDataPath: "", logsPath: "", logLevelFile: "", logLevelConsole: "", whisperLib: "" }),
+    },
+    analytics: {
+      track: vi.fn().mockResolvedValue(undefined),
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add `onboarding_skipped` and `onboarding_completed` analytics events with step tracking properties
- Fix shortcut banner flash on GeneralPanel when onboarding overlay is open (gate with `!onboardingOpen`)
- Make DevPanel onboarding button always visible (not gated behind `onboardingCompleted`) with reset capability
- Wire `analytics.track` IPC bridge through preload for renderer→main analytics calls
- Add `analytics` and `history.add` mocks to test setup helper

## Test plan
- [x] Existing onboarding tests pass (363/363)
- [x] New tests verify `onboarding_skipped` event fires with correct step property on skip
- [x] New tests verify `onboarding_completed` event fires on final step completion
- [x] Manual: complete onboarding and verify events in analytics dashboard
- [x] Manual: skip onboarding at various steps and verify step property
- [x] Manual: open DevPanel and trigger onboarding reset + reopen

```shell
00:49:13.087 (Analytics)        › Event captured { event: 'onboarding_completed' }
00:49:21.127 (Analytics)        › Event captured { event: 'onboarding_skipped' }
01:15:20.158 (Analytics)  › Event captured { event: 'onboarding_started' } (with is_first_time param)
```