### PR TITLE
chore(dx): add onboarding/settings consistency guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ Sections: `general.`, `whisper.`, `llm.`, `permissions.`, `shortcuts.`, `tray.`,
 - Transcribed speech content
 - User-entered content (custom prompts)
 
+## Onboarding and Settings Consistency
+
+The onboarding wizard (`src/renderer/components/onboarding/`) and the settings panels (`src/renderer/components/`) share UI components via `src/renderer/components/shared/`, `src/renderer/components/permissions/`, and `src/renderer/components/whisper/`. When modifying settings panels (WhisperPanel, PermissionsPanel, etc.), always check whether the corresponding onboarding step needs the same update — and vice versa. Shared components like `PermissionRow`, `ModelRow`, `RadioGroup`, and the `useWhisperTest` hook exist to keep both surfaces in sync.
+
 ## Validation: Run All Linters Before Completing Work
 
 Before claiming any implementation is done, you MUST run all validation commands and confirm they pass:


### PR DESCRIPTION
## Summary
- Add a guideline to `CLAUDE.md` reminding that onboarding steps and settings panels share components (`PermissionRow`, `ModelRow`, `RadioGroup`, `useWhisperTest`) and must be kept in sync when either surface is modified.

## Test plan
- [x] Documentation-only change, no code affected

⚠️ Depends on https://github.com/app-vox/vox/pull/224