### PR TITLE
chore(dx): add screenshots section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,7 @@ Brief description of the changes.
 - [ ] **CSS** — CSS Modules with CSS custom properties. No hardcoded color/spacing values.
 - [ ] **SVGs** — SVG assets in separate files, not inlined in TSX.
 - [ ] **Accessibility** — Interactive elements are keyboard-navigable with appropriate ARIA attributes.
+
+### Screenshots
+
+<!-- If there's anything visual to review (UI changes, new components, layout tweaks), drop screenshots or a short recording here. Remove this section if not applicable. -->


### PR DESCRIPTION
## Summary
Add a screenshots section to the PR template so reviewers can quickly see visual changes.

### Screenshots

<img width="650" alt="PR template diff — example of a broken img ofc" src="https://github.com/user-attachments/assets/placeholder">

<!-- ^ replace with actual screenshot after PR is created -->