### PR TITLE
fix(deps): override fast-xml-parser to 5.3.6 (CVE-2026-26278)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8358,9 +8358,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -8369,7 +8369,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "uiohook-napi": "^1.5.4",
     "whisper-node": "^1.1.1"
   },
+  "overrides": {
+    "fast-xml-parser": "5.3.6"
+  },
   "build": {
     "npmRebuild": false,
     "appId": "com.rodrigoluizs.vox",


### PR DESCRIPTION
## Summary
- Override `fast-xml-parser` from 5.3.4 to 5.3.6 to fix [CVE-2026-26278](https://avd.aquasec.com/nvd/cve-2026-26278) (HIGH — DoS through entity expansion in DOCTYPE)
- Transitive dependency via `@aws-sdk/xml-builder` → `@aws-sdk/core` → `@aws-sdk/client-bedrock-runtime`
- AWS SDK hasn't shipped the fix upstream yet, so using npm `overrides` until they do

## Test plan
- [x] `npm ls fast-xml-parser` confirms 5.3.6 overridden
- [x] `npm run typecheck` passes
- [x] `npm test` passes (351/351)
- [x] MegaLinter trivy scan should pass now