### PR TITLE
fix(analytics): allow devpanel test error to bypass enabled guard

### DIFF
--- a/src/main/analytics/service.ts
+++ b/src/main/analytics/service.ts
@@ -111,8 +111,8 @@ export class AnalyticsService {
     }
   }
 
-  captureError(error: Error, context?: Record<string, unknown>): void {
-    if (!this.enabled || !this.posthog) return;
+  captureError(error: Error, context?: Record<string, unknown>, { force = false }: { force?: boolean } = {}): void {
+    if ((!this.enabled && !force) || !this.posthog) return;
 
     try {
       const props = {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -206,7 +206,7 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.handle("dev:test-error", () => {
-    analytics.captureError(new Error("Test error from Dev Panel"), { scope: "devPanel" });
+    analytics.captureError(new Error("Test error from Dev Panel"), { scope: "devPanel" }, { force: true });
   });
 
   ipcMain.handle("dev:get-system-info", () => {


### PR DESCRIPTION
## Summary

The "Send Error" button in the DevPanel analytics section was silently failing — `captureError` early-returns when analytics is disabled, which is always the case in dev mode. Added an optional `{ force }` parameter so the `dev:test-error` handler can bypass the `enabled` check.

## Changes

- `src/main/analytics/service.ts` — added optional `{ force }` third parameter to `captureError`; the enabled guard now respects the force flag
- `src/main/app.ts` — pass `{ force: true }` in the `dev:test-error` IPC handler

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested — clicked "Send Error" in DevPanel, confirmed the error event reaches PostHog

## Code standards

- [x] **i18n** — No user-facing strings changed
- [x] **Dev Panel** — This fix is specifically for the Dev Panel test button
- [x] **CSS** — No CSS changes
- [x] **SVGs** — No SVG changes
- [x] **Accessibility** — No accessibility changes