### PR TITLE
fix(hud): restart hover tracking when returning to idle via direct setState

### DIFF
--- a/src/main/hud.ts
+++ b/src/main/hud.ts
@@ -906,6 +906,10 @@ export class HudWindow {
       this.window.showInactive();
       this.execSetScale(1.0);
     }
+
+    if (this.showOnHover && state === "idle" && this.alwaysShow) {
+      this.startHoverTracking();
+    }
   }
 
   sendAudioLevels(levels: number[]): void {


### PR DESCRIPTION
## Summary

When clicking "nothing heard" or "listening" pills in the HUD with "enlarge on proximity" enabled, the shrink-on-hover-out stopped working. `setState("idle")` called directly (via `dismissHud`/`stopAndProcess`) clears the flash timer but never restarts hover tracking — only the delayed error/canceled timeout callback did.

## Changes

- Restart `startHoverTracking()` inside `setState` when transitioning to idle with `showOnHover` and `alwaysShow` enabled

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested:
  - [x] Enable "enlarge on proximity" in settings
  - [x] Record something, let it show "nothing heard" (error/canceled pill)
  - [x] Click the pill to dismiss — HUD should shrink when cursor moves away
  - [x] Record and click "listening" pill to stop — same shrink behavior
  - [x] Normal proximity enlarge/shrink still works in idle state

#### Here:
<img width="196" height="70" alt="where the problem is" src="https://github.com/user-attachments/assets/5ea8dcb5-5c4a-4218-8cac-b5a44af90797" />

## Code standards

- [x] **i18n** — No user-facing strings changed
- [x] **Dev Panel** — N/A
- [x] **CSS** — N/A
- [x] **SVGs** — N/A
- [x] **Accessibility** — N/A