### PR TITLE
fix: make `Restart Now` button actually restart the app

### DIFF
--- a/src/main/hud.ts
+++ b/src/main/hud.ts
@@ -947,7 +947,7 @@ export class HudWindow {
   }
 
   private positionWindow(): void {
-    if (!this.window) return;
+    if (!this.window || this.window.isDestroyed()) return;
     const display = this.targetDisplayId !== null
       ? screen.getAllDisplays().find(d => d.id === this.targetDisplayId) ?? screen.getPrimaryDisplay()
       : screen.getDisplayNearestPoint(screen.getCursorScreenPoint());

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -126,4 +126,9 @@ export function quitAndInstall(): void {
   if (app.isPackaged) {
     autoUpdater.quitAndInstall(false, true);
   }
+
+  // Fallback: if autoUpdater didn't quit (e.g. no real update pending, or dev mode),
+  // relaunch the app manually so the "Restart Now" button always works.
+  app.relaunch();
+  app.exit(0);
 }


### PR DESCRIPTION
## Summary

Fix the "Restart Now" button doing nothing when clicked after an update is downloaded. Also fixes an `Object has been destroyed` crash during app shutdown.

Closes #250

## Changes

- **`src/main/updater.ts`** — Add `app.relaunch()` + `app.exit(0)` fallback after `autoUpdater.quitAndInstall()`. In production, autoUpdater kills the process before the fallback runs. In dev mode (or if autoUpdater silently fails), the fallback ensures the app actually restarts.
- **`src/main/hud.ts`** — Add missing `isDestroyed()` guard in `positionWindow()`, consistent with every other method in the class. Prevents crash when HUD window is accessed during shutdown.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (426 tests)
- [x] Manually tested — "Restart Now" button closes/restarts the app in dev mode. No more "Object has been destroyed" error dialog.

## Code standards

- [x] **i18n** — No user-facing strings changed.
- [x] **Dev Panel** — No new state added.
- [x] **CSS** — No CSS changes.
- [x] **SVGs** — No SVG changes.
- [x] **Accessibility** — No UI changes.