### PR TITLE
fix(llm): preserve provider config when switching or reselecting providers

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { AudioRecorder } from "./audio/recorder";
 import { transcribe } from "./audio/whisper";
 import { createLlmProvider } from "./llm/factory";
 import { computeLlmConfigHash } from "../shared/llm-config-hash";
-import { type VoxConfig, type WhisperModelSize } from "../shared/config";
+import { type VoxConfig, type LlmProviderType, type WhisperModelSize } from "../shared/config";
 import { getResourcePath } from "./resources";
 import { SetupChecker } from "./setup/checker";
 import { checkForUpdates, getUpdateState, quitAndInstall } from "./updater";
@@ -36,6 +36,10 @@ export function registerIpcHandlers(
 
   ipcMain.handle("config:load", () => {
     return configManager.load();
+  });
+
+  ipcMain.handle("config:load-llm-for-provider", (_event, provider: LlmProviderType) => {
+    return configManager.loadLlmForProvider(provider);
   });
 
   ipcMain.handle("config:save", (_event, config: VoxConfig) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,6 +43,7 @@ export interface UpdateState {
 export interface VoxAPI {
   config: {
     load(): Promise<import("../shared/config").VoxConfig>;
+    loadLlmForProvider(provider: import("../shared/config").LlmProviderType): Promise<import("../shared/config").LlmConfig>;
     save(config: import("../shared/config").VoxConfig): Promise<void>;
     onConfigChanged(callback: () => void): () => void;
   };
@@ -158,6 +159,7 @@ export interface VoxAPI {
 const voxApi: VoxAPI = {
   config: {
     load: () => ipcRenderer.invoke("config:load"),
+    loadLlmForProvider: (provider) => ipcRenderer.invoke("config:load-llm-for-provider", provider),
     save: (config) => ipcRenderer.invoke("config:save", config),
     onConfigChanged: (callback) => {
       const handler = () => callback();

--- a/src/renderer/components/llm/LlmPanel.tsx
+++ b/src/renderer/components/llm/LlmPanel.tsx
@@ -127,36 +127,9 @@ export function LlmPanel() {
     );
   }
 
-  const handleProviderChange = (provider: LlmProviderType) => {
-    let newLlm: LlmConfig;
-    switch (provider) {
-      case "foundry":
-        newLlm = { provider: "foundry", endpoint: "", apiKey: "", model: "gpt-4o" };
-        break;
-      case "bedrock":
-        newLlm = { provider: "bedrock", region: "us-east-1", profile: "", accessKeyId: "", secretAccessKey: "", modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0" };
-        break;
-      case "openai":
-        newLlm = { provider: "openai", openaiApiKey: "", openaiModel: "gpt-4o", openaiEndpoint: "https://api.openai.com" };
-        break;
-      case "deepseek":
-        newLlm = { provider: "deepseek", openaiApiKey: "", openaiModel: "deepseek-chat", openaiEndpoint: "https://api.deepseek.com" };
-        break;
-      case "glm":
-        newLlm = { provider: "glm", openaiApiKey: "", openaiModel: "glm-4", openaiEndpoint: "https://open.bigmodel.cn/api/paas/v4" };
-        break;
-      case "litellm":
-        newLlm = { provider: "litellm", openaiApiKey: "", openaiModel: "gpt-4o", openaiEndpoint: "http://localhost:4000" };
-        break;
-      case "anthropic":
-        newLlm = { provider: "anthropic", anthropicApiKey: "", anthropicModel: "claude-sonnet-4-20250514" };
-        break;
-      case "custom":
-        newLlm = { provider: "custom", customEndpoint: "", customToken: "", customTokenAttr: "Authorization", customTokenSendAs: "header", customModel: "" };
-        break;
-      default:
-        newLlm = { provider: "foundry", endpoint: "", apiKey: "", model: "gpt-4o" };
-    }
+  const handleProviderChange = async (provider: LlmProviderType) => {
+    if (provider === config.llm.provider) return;
+    const newLlm = await window.voxApi.config.loadLlmForProvider(provider);
     updateConfig({ llm: newLlm });
     saveConfig(true);
   };


### PR DESCRIPTION
## Summary

Fixes LLM provider config being wiped when switching providers or reselecting the current one. The dropdown handler previously replaced all fields with hardcoded defaults, losing any previously entered API keys, endpoints, and model selections.

## Changes

- **Early return on same-provider reselection** — clicking the already-active provider in the dropdown is now a no-op, preventing accidental credential wipe
- **New `ConfigManager.loadLlmForProvider(provider)`** — reads the flat config from disk and narrows it to the requested provider, restoring previously saved credentials (with decryption)
- **New IPC channel `config:load-llm-for-provider`** — wired through `ipcMain.handle` and the preload bridge so the renderer can request per-provider config
- **Simplified `handleProviderChange`** — reduced from a 33-line switch statement to 4 lines that delegates to the new IPC
- **4 new unit tests** covering: defaults when no config exists, credential restoration after provider switch, current provider round-trip, and secret decryption

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested:
  - Select OpenAI, enter API key and model, save
  - Click provider dropdown and select OpenAI again — config preserved (no-op)
  - Switch to Anthropic, enter API key, save
  - Switch back to OpenAI — previous API key and model restored
  - Switch to a never-configured provider — shows defaults

## Code standards

- [x] **i18n** — No new user-facing strings (logic-only change)
- [x] **Dev Panel** — N/A
- [x] **CSS** — N/A
- [x] **SVGs** — N/A
- [x] **Accessibility** — N/A

Closes #247