### PR TITLE
fix(settings): enable speech download and guard HUD toggle on setup state

### DIFF
--- a/src/renderer/components/general/GeneralPanel.tsx
+++ b/src/renderer/components/general/GeneralPanel.tsx
@@ -535,10 +535,11 @@ export function GeneralPanel() {
         </button>
         {!displayCollapsed && (
           <div className={card.body}>
-            <label className={styles.checkboxRow}>
+            <label className={`${styles.checkboxRow} ${!setupComplete ? styles.disabled : ""}`}>
               <input
                 type="checkbox"
                 checked={config.showHud}
+                disabled={!setupComplete}
                 onChange={async () => {
                   const newShowHud = !config.showHud;
                   updateConfig({
@@ -555,11 +556,11 @@ export function GeneralPanel() {
               </div>
             </label>
 
-            <label className={`${styles.checkboxRow} ${!config.showHud ? styles.disabled : ""}`}>
+            <label className={`${styles.checkboxRow} ${!config.showHud || !setupComplete ? styles.disabled : ""}`}>
               <input
                 type="checkbox"
                 checked={config.hudShowOnHover}
-                disabled={!config.showHud}
+                disabled={!config.showHud || !setupComplete}
                 onChange={async () => {
                   updateConfig({ hudShowOnHover: !config.hudShowOnHover });
                   await saveConfig(false);
@@ -572,11 +573,11 @@ export function GeneralPanel() {
               </div>
             </label>
 
-            <label className={`${styles.checkboxRow} ${!config.showHud ? styles.disabled : ""}`}>
+            <label className={`${styles.checkboxRow} ${!config.showHud || !setupComplete ? styles.disabled : ""}`}>
               <input
                 type="checkbox"
                 checked={config.showHudActions}
-                disabled={!config.showHud}
+                disabled={!config.showHud || !setupComplete}
                 onChange={async () => {
                   updateConfig({ showHudActions: !config.showHudActions });
                   await saveConfig(false);

--- a/src/renderer/components/whisper/WhisperPanel.tsx
+++ b/src/renderer/components/whisper/WhisperPanel.tsx
@@ -57,7 +57,7 @@ export function WhisperPanel() {
           onDownload={modelManager.download}
           onCancel={modelManager.cancelDownload}
           onDelete={modelManager.deleteModel}
-          downloadDisabled={!online || setupComplete === false}
+          downloadDisabled={!online}
         />
 
         <div className={form.testSection}>


### PR DESCRIPTION
## Summary

- Remove `setupComplete === false` guard from `downloadDisabled` in **WhisperPanel** so the download button works on first launch (same fix already applied to onboarding in #253)
- Disable the **HUD always-on toggle** and its child options (show on hover, show actions) in **GeneralPanel** when no speech model is downloaded, following the existing disabled-toggle pattern already used by the child toggles

## Test plan

- [x] Fresh install (or delete all models): Speech panel download button is enabled and functional
- [x] With no model downloaded, General > HUD toggle is grayed out and not clickable
- [x] Download a model: HUD toggle becomes enabled
- [x] With HUD enabled, child toggles (show on hover, show actions) work as before
- [x] Onboarding flow still works correctly end-to-end

Closes #263