### PR TITLE
feat(landing): add PostHog analytics tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# Vox Landing Page Guidelines
+
+## Branch
+
+This is the `gh-pages` branch — a static site served at https://app-vox.github.io/vox/. It is completely separate from the main app codebase.
+
+## PostHog Analytics
+
+PostHog is configured with the same project used by the desktop app, using the `posthog-js` browser SDK loaded via CDN snippet in `index.html`.
+
+- **API Key**: `phc_xKMWJw3NXHbfxhW10c3QG3nKTFRGio4PtVeJVfo0lNu`
+- **Host**: `https://us.i.posthog.com`
+- **Person profiles**: `anonymous` (no PII)
+- **Auto-capture**: pageview, pageleave, and Web Vitals (LCP, CLS, INP, FCP, TTFB) enabled
+
+### Adding events
+
+Every new interactive element (button, link, toggle) must have a PostHog event. Use the `trackEvent` helper in `script.js`:
+
+```js
+trackEvent('event_name', { key: 'value' });
+```
+
+### Naming conventions
+
+- Use `snake_case` for event names
+- Be descriptive: `download_click`, `github_click`, `theme_toggle`
+- Include context via params: `{ platform: 'macos' }`, `{ location: 'header' }`
+- Keep consistent with the desktop app event naming in `src/main/analytics/`
+
+### Current tracked events
+
+| Event | Params | Element |
+|---|---|---|
+| `download_click` | `platform` | Download for macOS button |
+| `github_click` | `location` | GitHub stars badge, Star on GitHub button |
+| `language_switch` | `language` | Language selector |
+| `theme_toggle` | `theme` | Dark/light toggle |
+| `footer_link_click` | `label` | Footer nav links (Docs, GitHub, MIT License) |
+
+## i18n
+
+All user-facing text uses the i18n system in `i18n.js`. When adding new text, add keys to all locale objects.
+
+## Structure
+
+- `index.html` — Landing page markup
+- `style.css` — Styles with dark/light theme support
+- `script.js` — Interactive features, animations, PostHog tracking
+- `i18n.js` — Internationalization (9 languages)
+- `assets/` — Images and static assets

--- a/index.html
+++ b/index.html
@@ -59,6 +59,18 @@
     <link rel="alternate" hreflang="tr" href="https://app-vox.github.io/vox/" />
     <link rel="alternate" hreflang="x-default" href="https://app-vox.github.io/vox/" />
 
+    <!-- PostHog Analytics -->
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once unregister opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('phc_xKMWJw3NXHbfxhW10c3QG3nKTFRGio4PtVeJVfo0lNu', {
+            api_host: 'https://us.i.posthog.com',
+            person_profiles: 'anonymous',
+            capture_pageview: true,
+            capture_pageleave: true,
+            capture_performance: { web_vitals: true }
+        });
+    </script>
+
     <!-- Stylesheet -->
     <link rel="stylesheet" href="style.css">
 

--- a/script.js
+++ b/script.js
@@ -1,3 +1,14 @@
+// PostHog Event Tracking
+const ANALYTICS_DEBUG = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+const trackEvent = (eventName, params = {}) => {
+    if (ANALYTICS_DEBUG) {
+        console.log(`[PostHog] ${eventName}`, params);
+    }
+    if (typeof posthog !== 'undefined' && posthog.capture) {
+        posthog.capture(eventName, params);
+    }
+};
+
 // OS and Architecture Detection
 const detectOS = () => {
     const userAgent = window.navigator.userAgent.toLowerCase();
@@ -45,6 +56,11 @@ const updateDownloadButton = () => {
     const downloadText = document.getElementById('download-text');
     const platformNote = document.getElementById('platform-note');
     const { os } = detectOS();
+
+    // Track download button clicks
+    downloadBtn.addEventListener('click', () => {
+        trackEvent('download_click', { platform: os });
+    });
 
     // Enable download for any macOS
     if (os !== 'macos') {
@@ -101,6 +117,7 @@ const initLanguageSwitcher = () => {
     menuButtons.forEach(button => {
         button.addEventListener('click', () => {
             const lang = button.getAttribute('data-lang');
+            trackEvent('language_switch', { language: lang });
             window.i18n.setLanguage(lang);
             menu.classList.remove('active');
 
@@ -147,6 +164,7 @@ themeToggle.addEventListener('click', () => {
     const currentTheme = html.getAttribute('data-theme');
     const newTheme = currentTheme === 'light' ? 'dark' : 'light';
     setTheme(newTheme);
+    trackEvent('theme_toggle', { theme: newTheme });
 });
 
 // Listen for system theme changes
@@ -389,6 +407,27 @@ document.addEventListener('DOMContentLoaded', () => {
     if (demoContainer) {
         demoObserver.observe(demoContainer);
     }
+
+    // 6. Event tracking for outbound links
+    const githubStars = document.getElementById('github-stars');
+    if (githubStars) {
+        githubStars.addEventListener('click', () => {
+            trackEvent('github_click', { location: 'header_stars' });
+        });
+    }
+
+    const starBtn = document.querySelector('.btn-secondary[href*="github.com/app-vox/vox"]');
+    if (starBtn) {
+        starBtn.addEventListener('click', () => {
+            trackEvent('github_click', { location: 'hero_star_button' });
+        });
+    }
+
+    document.querySelectorAll('.footer-nav a').forEach(link => {
+        link.addEventListener('click', () => {
+            trackEvent('footer_link_click', { label: link.textContent.trim() });
+        });
+    });
 });
 
 // Smooth scroll for anchor links


### PR DESCRIPTION
## Summary
- Add PostHog analytics (`posthog-js` CDN snippet) using the same project as the desktop app
- Add `trackEvent` helper with debug logging on localhost
- Track interactive elements: download button, GitHub links, language switch, theme toggle, footer links
- Add `CLAUDE.md` with PostHog analytics guidelines and event naming conventions

## Test plan
- [x] Open landing page and verify PostHog loads (check Network tab for `us.i.posthog.com` requests)
- [x] Toggle theme and verify `theme_toggle` event in PostHog Live Events
- [x] Click GitHub links and verify `github_click` events
- [x] Click download button and verify `download_click` event with platform param
- [x] Switch language and verify `language_switch` event
- [x] Click footer links and verify `footer_link_click` events
- [x] On localhost, verify `[PostHog]` debug logs appear in browser console
- [x] Verify pageview and pageleave auto-capture in PostHog dashboard

### How
<img width="417" height="179" alt="this is how logs are shown" src="https://github.com/user-attachments/assets/825058c4-ffff-4516-930d-708aded9e429" />

Closes https://github.com/app-vox/vox/issues/216