### PR TITLE
fix(ui): stack permission row badge and button to prevent cramping

### DIFF
--- a/src/renderer/components/ui/PermissionRequest.module.scss
+++ b/src/renderer/components/ui/PermissionRequest.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--spacing-3);
   padding: var(--spacing-4) 0;
   border-bottom: 1px solid var(--color-border);
 
@@ -14,6 +15,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
+  min-width: 0;
   color: var(--color-text-secondary);
 }
 
@@ -31,10 +33,9 @@
 
 .action {
   display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  flex-shrink: 0;
-  white-space: nowrap;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--spacing-1);
 }
 
 .badge {


### PR DESCRIPTION
## Summary

Fix cramped layout in permission row when badge and button are displayed side by side, especially visible in non-English locales with longer labels (de, ru, pt-BR).

## Changes

- `.row`: added `gap: var(--spacing-3)` for minimum spacing between info and action areas
- `.info`: added `min-width: 0` so info side can shrink properly in flex layout
- `.action`: replaced `flex-shrink: 0; white-space: nowrap` with `flex-direction: column; align-items: flex-end; gap: var(--spacing-1)` — badge and button now stack vertically, aligned right

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested — verified permission rows in both settings panel and onboarding wizard render correctly across all supported locales

### Screenshots
permissions screen:
<img width="706" height="454" alt="image" src="https://github.com/user-attachments/assets/53dd7114-e974-4c30-be5e-fa9c9abd6a86" />

onboarding:
<img width="797" height="614" alt="image" src="https://github.com/user-attachments/assets/9442b617-ad74-4768-9da1-917166bbb89f" />

## Code standards

- [x] **i18n** — No user-facing strings changed (SCSS only)
- [x] **Dev Panel** — N/A
- [x] **CSS** — CSS Modules with CSS custom properties. No hardcoded color/spacing values.
- [x] **SVGs** — N/A
- [x] **Accessibility** — No changes to interactive elements

Closes #265