### PR TITLE
feat(config): per-provider LLM config storage

### DIFF
--- a/src/renderer/components/llm/LlmPanel.tsx
+++ b/src/renderer/components/llm/LlmPanel.tsx
@@ -130,7 +130,7 @@ export function LlmPanel() {
   const handleProviderChange = async (provider: LlmProviderType) => {
     if (provider === config.llm.provider) return;
     const newLlm = await window.voxApi.config.loadLlmForProvider(provider);
-    updateConfig({ llm: newLlm });
+    updateConfig({ llm: newLlm, llmConnectionTested: false, llmConfigHash: "" });
     saveConfig(true);
   };
 


### PR DESCRIPTION
## Summary
- Adds independent storage for OpenAI-compatible providers (deepseek, glm, litellm) so switching providers no longer overwrites each other's saved credentials
- Adds `spreadLlmToFlat()` for mapping runtime config back to provider-specific flat fields
- Adds migration for existing configs that used shared `openai*` fields
- Resets `llmConnectionTested`/`llmConfigHash` on provider switch in the UI
- Comprehensive test coverage for narrow, spread, and independence

## Test plan
- [x] Configure DeepSeek with API key, switch to OpenAI, configure different key, switch back — DeepSeek key should be preserved
- [x] Same test with GLM and LiteLLM providers
- [x] Existing configs with shared openai fields should migrate correctly on first load
- [x] Run `npx vitest run` — all tests pass