### PR TITLE
fix(llm): rebuild pipeline after successful connection test

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -134,6 +134,7 @@ export function registerIpcHandlers(
       config.llmConnectionTested = true;
       config.llmConfigHash = computeLlmConfigHash(config);
       configManager.save(config);
+      onConfigChange?.();
 
       return { ok: true };
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Calls `onConfigChange()` after a successful LLM connection test so the pipeline rebuilds with the correct provider instead of keeping `NoopProvider`

## Test plan
- [x] Enable AI enhancement, configure a provider, run connection test — verify LLM enhancement is active in subsequent transcriptions
- [x] Run `npx vitest run` — all tests pass