### PR TITLE
fix(llm): add (initial) provider selection placeholder when unconfigured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -897,6 +897,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1233,6 +1234,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1346,6 +1348,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1386,6 +1389,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1804,7 +1808,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1826,7 +1829,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1843,7 +1845,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1858,7 +1859,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -4962,8 +4962,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5134,6 +5133,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5144,6 +5144,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5222,6 +5223,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -5629,6 +5631,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5662,6 +5665,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6163,6 +6167,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6815,8 +6820,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7135,6 +7139,7 @@
       "integrity": "sha512-sFZflH2BfU81rOFQgA3dYZFTwXeIUIwualuAYWovutR7W3VwImfHeT52fom6P+SS27INLs/zHSlKvh8kTi5l7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.0",
         "builder-util": "26.8.0",
@@ -7216,8 +7221,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -7625,7 +7629,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -7646,7 +7649,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -7883,6 +7885,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9378,6 +9381,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -9919,7 +9923,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10352,7 +10355,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10926,6 +10928,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11009,6 +11012,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11043,7 +11047,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11061,7 +11064,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -11082,7 +11084,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11098,7 +11099,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11226,6 +11226,7 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11236,6 +11237,7 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11248,8 +11250,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -11476,7 +11477,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11509,6 +11509,7 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11616,6 +11617,7 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12067,6 +12069,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -12545,7 +12548,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -12814,6 +12816,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13014,6 +13017,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13588,6 +13592,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -13953,6 +13958,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/renderer/components/dev/DevPanel.tsx
+++ b/src/renderer/components/dev/DevPanel.tsx
@@ -8,6 +8,7 @@ import { useTranscriptionsStore } from "../../stores/transcriptions-store";
 import { useSaveToast } from "../../hooks/use-save-toast";
 import { useOnlineStatus } from "../../hooks/use-online-status";
 import { computeLlmConfigHash } from "../../../shared/llm-config-hash";
+import { isProviderConfigured } from "../llm/LlmPanel";
 import { SUPPORTED_LANGUAGES } from "../../../shared/i18n";
 import { RefreshIcon, InfoCircleIcon } from "../../../shared/icons";
 import card from "../shared/card.module.scss";
@@ -288,6 +289,8 @@ export function DevPanel() {
     }
   })();
 
+  const llmConfigured = config ? isProviderConfigured(config.llm.provider, config.llm) : false;
+
   const modelName = (() => {
     if (!config) return "unknown";
     const llm = config.llm;
@@ -465,9 +468,19 @@ export function DevPanel() {
     },
     {
       title: "LLM",
-      overrideFields: ["llmEnhancementEnabled", "llmConnectionTested"],
+      overrideFields: ["llmEnhancementEnabled", "llmConnectionTested", "llmProviderConfigured"],
       rows: [
         { label: "Provider", render: () => <>{llmProvider}</> },
+        {
+          label: "Configured",
+          overrideField: "llmProviderConfigured",
+          render: () => (
+            <>
+              <span className={styles.realValue}>{boolDot(llmConfigured)}</span>
+              {ov && <OverrideBool field="llmProviderConfigured" {...ovProps} />}
+            </>
+          ),
+        },
         {
           label: "Enhancement",
           overrideField: "llmEnhancementEnabled",

--- a/src/renderer/components/dictionary/DictionaryPanel.tsx
+++ b/src/renderer/components/dictionary/DictionaryPanel.tsx
@@ -56,6 +56,11 @@ export function DictionaryPanel() {
     ? useDevOverrideValue("llmConnectionTested", realLlmTested)
     : realLlmTested;
 
+  const devLlmConfigured = import.meta.env.DEV
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    ? useDevOverrideValue("llmProviderConfigured", undefined)
+    : undefined;
+
   const showInfoBanner = !setupComplete || !llmEnabled;
 
   const [inputValue, setInputValue] = useState("");
@@ -70,7 +75,8 @@ export function DictionaryPanel() {
 
   if (!config) return null;
 
-  const llmReady = llmEnabled === true
+  const llmReady = devLlmConfigured !== false
+    && llmEnabled === true
     && llmTested === true
     && computeLlmConfigHash(config) === config.llmConfigHash;
 

--- a/src/renderer/components/layout/Sidebar.tsx
+++ b/src/renderer/components/layout/Sidebar.tsx
@@ -122,6 +122,11 @@ export function Sidebar() {
     ? useDevOverrideValue("llmConnectionTested", undefined)
     : undefined;
 
+  const devLlmConfigured = import.meta.env.DEV
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    ? useDevOverrideValue("llmProviderConfigured", undefined)
+    : undefined;
+
   const devOverridesActive = import.meta.env.DEV
     // eslint-disable-next-line react-hooks/rules-of-hooks
     ? useDevOverridesActive()
@@ -178,6 +183,7 @@ export function Sidebar() {
     if (type === "speech") return setupComplete;
     if (type === "permissions") return permissionStatus?.accessibility === true && permissionStatus?.microphone === "granted";
     if (type === "ai-enhancement") {
+      if (devLlmConfigured === false) return false;
       return setupComplete
         && effectiveLlmEnhancement === true
         && effectiveLlmTested === true

--- a/src/renderer/stores/dev-overrides-store.ts
+++ b/src/renderer/stores/dev-overrides-store.ts
@@ -13,6 +13,7 @@ export interface DevOverrides {
   online?: boolean;
   llmEnhancementEnabled?: boolean;
   llmConnectionTested?: boolean;
+  llmProviderConfigured?: boolean;
   analyticsDevEnabled?: boolean;
   hideDevVisuals?: boolean;
   visitedShortcuts?: boolean;

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Anbieter",
   "llm.customPromptTab": "Benutzerdefinierter Prompt",
   "llm.providerLabel": "Anbieter",
+  "llm.selectProvider": "Auswählen",
   "llm.testConnection": "Verbindung testen",
   "llm.testingConnection": "Verbindung wird getestet...",
   "llm.connectionSuccessful": "Verbindung erfolgreich",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -122,6 +122,7 @@
   "llm.providerTab": "Provider",
   "llm.customPromptTab": "Custom Prompt",
   "llm.providerLabel": "Provider",
+  "llm.selectProvider": "Select",
   "llm.testConnection": "Test Connection",
   "llm.testingConnection": "Testing connection...",
   "llm.connectionSuccessful": "Connection successful",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Proveedor",
   "llm.customPromptTab": "Prompt Personalizado",
   "llm.providerLabel": "Proveedor",
+  "llm.selectProvider": "Seleccione",
   "llm.testConnection": "Probar Conexión",
   "llm.testingConnection": "Probando conexión...",
   "llm.connectionSuccessful": "Conexión exitosa",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Fournisseur",
   "llm.customPromptTab": "Prompt personnalisé",
   "llm.providerLabel": "Fournisseur",
+  "llm.selectProvider": "Sélectionnez",
   "llm.testConnection": "Tester la connexion",
   "llm.testingConnection": "Test de connexion...",
   "llm.connectionSuccessful": "Connexion réussie",

--- a/src/shared/i18n/locales/it.json
+++ b/src/shared/i18n/locales/it.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Fornitore",
   "llm.customPromptTab": "Prompt personalizzato",
   "llm.providerLabel": "Fornitore",
+  "llm.selectProvider": "Seleziona",
   "llm.testConnection": "Testa connessione",
   "llm.testingConnection": "Test connessione...",
   "llm.connectionSuccessful": "Connessione riuscita",

--- a/src/shared/i18n/locales/pl.json
+++ b/src/shared/i18n/locales/pl.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Dostawca",
   "llm.customPromptTab": "Własny prompt",
   "llm.providerLabel": "Dostawca",
+  "llm.selectProvider": "Wybierz",
   "llm.testConnection": "Testuj połączenie",
   "llm.testingConnection": "Testowanie połączenia...",
   "llm.connectionSuccessful": "Połączenie udane",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Provedor",
   "llm.customPromptTab": "Prompt Personalizado",
   "llm.providerLabel": "Provedor",
+  "llm.selectProvider": "Selecione",
   "llm.testConnection": "Testar Conexão",
   "llm.testingConnection": "Testando conexão...",
   "llm.connectionSuccessful": "Conexão bem-sucedida",

--- a/src/shared/i18n/locales/pt-PT.json
+++ b/src/shared/i18n/locales/pt-PT.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Fornecedor",
   "llm.customPromptTab": "Prompt Personalizado",
   "llm.providerLabel": "Fornecedor",
+  "llm.selectProvider": "Selecione",
   "llm.testConnection": "Testar Ligação",
   "llm.testingConnection": "A testar ligação...",
   "llm.connectionSuccessful": "Ligação bem-sucedida",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Провайдер",
   "llm.customPromptTab": "Пользовательский промпт",
   "llm.providerLabel": "Провайдер",
+  "llm.selectProvider": "Выберите",
   "llm.testConnection": "Тест соединения",
   "llm.testingConnection": "Тестирование соединения...",
   "llm.connectionSuccessful": "Соединение успешно",

--- a/src/shared/i18n/locales/tr.json
+++ b/src/shared/i18n/locales/tr.json
@@ -119,6 +119,7 @@
   "llm.providerTab": "Sağlayıcı",
   "llm.customPromptTab": "Özel Prompt",
   "llm.providerLabel": "Sağlayıcı",
+  "llm.selectProvider": "Seçiniz",
   "llm.testConnection": "Bağlantıyı Test Et",
   "llm.testingConnection": "Bağlantı test ediliyor...",
   "llm.connectionSuccessful": "Bağlantı başarılı",

--- a/tests/renderer/components/LlmPanel.test.tsx
+++ b/tests/renderer/components/LlmPanel.test.tsx
@@ -153,10 +153,30 @@ describe("LlmPanel", () => {
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
   });
 
-  it("shows provider fields when enhancement is enabled", async () => {
+  it("shows placeholder when enhancement is enabled but provider not configured", async () => {
     const LlmPanel = await loadLlmPanel();
     const config = createDefaultConfig();
     config.enableLlmEnhancement = true;
+
+    useConfigStore.setState({ config, setupComplete: true });
+
+    renderWithI18n(<LlmPanel />);
+
+    // Provider select should be visible
+    expect(screen.getByTestId("llm-provider")).toBeInTheDocument();
+    // But no provider fields since no provider has been configured/tested
+    expect(screen.queryByTestId("foundry-fields")).not.toBeInTheDocument();
+    // Test connection button should be disabled
+    const buttons = screen.getAllByRole("button");
+    const testButton = buttons.find((btn) => btn.querySelector("[data-testid='play-icon']"));
+    expect(testButton).toBeDisabled();
+  });
+
+  it("shows provider fields when enhancement is enabled and provider was previously tested", async () => {
+    const LlmPanel = await loadLlmPanel();
+    const config = createDefaultConfig();
+    config.enableLlmEnhancement = true;
+    config.llmConfigHash = "previously-tested";
 
     useConfigStore.setState({ config, setupComplete: true });
 
@@ -187,6 +207,7 @@ describe("LlmPanel", () => {
     const config = createDefaultConfig();
     config.enableLlmEnhancement = true;
     config.llm.provider = "bedrock";
+    config.llmConfigHash = "previously-tested";
 
     useConfigStore.setState({ config, setupComplete: true });
 
@@ -201,6 +222,7 @@ describe("LlmPanel", () => {
     const config = createDefaultConfig();
     config.enableLlmEnhancement = true;
     config.llm.provider = "openai";
+    config.llmConfigHash = "previously-tested";
 
     useConfigStore.setState({ config, setupComplete: true });
 
@@ -215,6 +237,7 @@ describe("LlmPanel", () => {
     const user = userEvent.setup();
     const config = createDefaultConfig();
     config.enableLlmEnhancement = true;
+    config.llmConfigHash = "previously-tested";
 
     useConfigStore.setState({ config, setupComplete: true });
 
@@ -249,6 +272,7 @@ describe("LlmPanel", () => {
     const user = userEvent.setup();
     const config = createDefaultConfig();
     config.enableLlmEnhancement = true;
+    config.llmConfigHash = "previously-tested";
 
     useConfigStore.setState({ config, setupComplete: true });
 


### PR DESCRIPTION
## Summary

Show a "Select" placeholder in the provider dropdown when AI enhancement is enabled but no provider has been configured or tested. This prevents users from seeing an empty or confusing provider state.

## Changes

- Add "Select" placeholder option to LLM provider dropdown when no provider is configured
- Hide provider-specific fields and disable "Test Connection" button when in placeholder state
- Add `llmProviderConfigured` dev override to DevPanel, Sidebar, and Dictionary
- Add i18n key `llm.selectProvider` to all 10 locale files
- Add test coverage for the placeholder state in LlmPanel tests

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested (describe how)
  - [x] Enable AI Enhancement with fresh config — should show "Select" placeholder
  - [x] Pick a provider — fields appear, test connection enabled
  - [x] Toggle `llmProviderConfigured` override in DevPanel — placeholder state is forced
  - [x] Sidebar and Dictionary reflect unconfigured state via override

## Code standards

- [x] **i18n** — All user-facing strings use the translation system. New keys added to **all** locale files.
- [x] **Dev Panel** — New internal state is exposed in the Dev Panel where useful for debugging.
- [x] **CSS** — CSS Modules with CSS custom properties. No hardcoded color/spacing values.
- [x] **SVGs** — SVG assets in separate files, not inlined in TSX.
- [x] **Accessibility** — Interactive elements are keyboard-navigable with appropriate ARIA attributes.

### Screenshots

<img width="711" height="496" alt="image" src="https://github.com/user-attachments/assets/0d31c956-044c-4483-920e-8fa346467092" />