### PR TITLE
fix(electron): prevent race condition in quit-and-install flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	npm run dist
 
 build-dev:
-	npm run build && CSC_IDENTITY_AUTO_DISCOVERY=false SKIP_NOTARIZE=1 npx electron-builder --mac dir
+	npm run build && CSC_IDENTITY_AUTO_DISCOVERY=false SKIP_NOTARIZE=1 npx electron-builder --mac dir -c.mac.provisioningProfile=
 	@printf 'provider: github\nowner: app-vox\nrepo: vox\n' > out/mac-arm64/Vox.app/Contents/Resources/app-update.yml
 
 install:

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -125,10 +125,9 @@ export function getUpdateState(): UpdateState {
 export function quitAndInstall(): void {
   if (app.isPackaged) {
     autoUpdater.quitAndInstall(false, true);
+    return;
   }
 
-  // Fallback: if autoUpdater didn't quit (e.g. no real update pending, or dev mode),
-  // relaunch the app manually so the "Restart Now" button always works.
   app.relaunch();
   app.exit(0);
 }


### PR DESCRIPTION
## Summary

- Fix `Restart Now` button not working after update download
- Root cause: `app.relaunch()` + `app.exit(0)` was racing with `autoUpdater.quitAndInstall()` ShipIt mechanism on macOS, killing the process before the update could be applied
- Add early `return` so the fallback relaunch only runs in dev mode
- Fix `build-dev` Makefile target to skip provisioning profile requirement

## Test plan

- [ ] Build a signed production release with a lower version number
- [ ] Install, check for updates, verify "Restart Now" quits and relaunches with the new version
- [ ] Verify dev mode restart still works via `app.relaunch()` fallback

Ref: [ACCEL-517](https://hellofresh.atlassian.net/browse/ACCEL-517)