### PR TITLE
fix(build): resolve electron-builder asar packaging failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,10 +147,10 @@ jobs:
         with:
           name: vox-${{ needs.version.outputs.version }}-mac-arm64
           path: |
-            out/*.dmg
-            out/*.zip
-            out/*.blockmap
-            out/latest-mac.yml
+            dist/*.dmg
+            dist/*.zip
+            dist/*.blockmap
+            dist/latest-mac.yml
           if-no-files-found: error
 
   release:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "appId": "com.rodrigoluizs.vox",
     "productName": "Vox",
     "directories": {
-      "output": "out"
+      "output": "dist"
     },
     "afterSign": "build/notarize.cjs",
     "mac": {
@@ -109,7 +109,7 @@
       ]
     },
     "files": [
-      "out/**/*",
+      "out{,/**/*}",
       "resources/**/*",
       "node_modules/**/*",
       "!node_modules/*/{CHANGELOG.md,README.md,readme.md}"


### PR DESCRIPTION
## Summary

- The release pipeline fails because `out/main/index.js` is missing from the asar archive
- **Root cause**: `minimatch` 10.2.3 (security update) changed partial matching behavior — `out/**/*` no longer matches the `out` directory for traversal. Combined with electron-builder auto-excluding its output directory (`!out{,/**/*}` from `directories.output: "out"`), the entire vite build output gets skipped during asar packaging
- **Fix**: Move electron-builder output to `dist/` and use `out{,/**/*}` glob to explicitly match both the directory and its contents

## Test plan

- [x] Verified locally: clean build + `electron-builder --mac dir` succeeds, asar contains `out/main/index.js`, `out/preload/index.js`, `out/renderer/`
- [x] All 488 tests pass
- [x] Re-run the release pipeline after merge to confirm CI fix