### PR TITLE
chore(css): fix all lint:css and check:tokens errors and enforce in CI

### DIFF
--- a/.github/scripts/post-ci-summary.sh
+++ b/.github/scripts/post-ci-summary.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Posts (or updates) a CI summary comment on a pull request.
 # Required env vars: REPO, PR_NUMBER, RUN_NUMBER, RUN_URL,
-#   TYPECHECK_OUTCOME, LINT_OUTCOME, TEST_OUTCOME, BUILD_OUTCOME
+#   TYPECHECK_OUTCOME, LINT_OUTCOME, LINT_CSS_OUTCOME, CHECK_TOKENS_OUTCOME,
+#   TEST_OUTCOME, BUILD_OUTCOME
 
 status_icon() {
   case "$1" in
@@ -15,6 +16,8 @@ status_icon() {
 
 TYPECHECK=$(status_icon "$TYPECHECK_OUTCOME")
 LINT=$(status_icon "$LINT_OUTCOME")
+LINT_CSS=$(status_icon "$LINT_CSS_OUTCOME")
+CHECK_TOKENS=$(status_icon "$CHECK_TOKENS_OUTCOME")
 TEST=$(status_icon "$TEST_OUTCOME")
 BUILD=$(status_icon "$BUILD_OUTCOME")
 
@@ -27,6 +30,8 @@ BODY="${MARKER}
 |-------|--------|
 | Typecheck | ${TYPECHECK} |
 | Lint | ${LINT} |
+| Lint CSS | ${LINT_CSS} |
+| Design Tokens | ${CHECK_TOKENS} |
 | Test | ${TEST} |
 | Build | ${BUILD} |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
         id: lint
         run: npm run lint
 
+      - name: Lint CSS
+        id: lint_css
+        run: npm run lint:css
+
+      - name: Check design tokens
+        id: check_tokens
+        run: npm run check:tokens
+
       - name: Test
         id: test
         run: npm run test:coverage
@@ -62,6 +70,8 @@ jobs:
           REPO: ${{ github.repository }}
           TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
+          LINT_CSS_OUTCOME: ${{ steps.lint_css.outcome }}
+          CHECK_TOKENS_OUTCOME: ${{ steps.check_tokens.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
           BUILD_OUTCOME: ${{ steps.build.outcome }}
         run: .github/scripts/post-ci-summary.sh

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,15 +4,38 @@
     "custom-property-pattern": null,
     "selector-class-pattern": null,
     "scss/dollar-variable-pattern": null,
+    "scss/at-rule-no-unknown": [true, { "ignoreAtRules": ["theme"] }],
     "color-hex-length": "long",
+    "property-no-vendor-prefix": [
+      true,
+      {
+        "ignoreProperties": [
+          "-webkit-user-select",
+          "-webkit-backdrop-filter",
+          "-webkit-app-region"
+        ]
+      }
+    ],
+    "property-no-unknown": [true, { "ignoreProperties": ["composes"] }],
+    "selector-pseudo-class-no-unknown": [
+      true,
+      { "ignorePseudoClasses": ["global"] }
+    ],
+    "value-keyword-case": ["lower", { "ignoreProperties": ["composes"] }],
     "declaration-property-unit-allowed-list": {
-      "border": ["px"],
+      "border": ["px", "%"],
       "border-width": ["px"],
-      "border-top": ["px"],
-      "border-right": ["px"],
-      "border-bottom": ["px"],
-      "border-left": ["px"]
+      "border-top": ["px", "%"],
+      "border-right": ["px", "%"],
+      "border-bottom": ["px", "%"],
+      "border-left": ["px", "%"]
     }
   },
-  "ignoreFiles": ["**/node_modules/**", "**/dist/**", "**/*.js", "**/*.ts", "**/*.tsx"]
+  "ignoreFiles": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/*.js",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -31,7 +31,14 @@ For pull requests and future development, reference this document to use existin
 - `--color-btn-primary-text` - Primary button text
 - `--color-success` - Success state (green)
 - `--color-error` - Error state (red)
+- `--color-error-hover` - Error hover state (darker red)
+- `--color-error-active` - Error active/pressed state (darkest red)
 - `--color-warning` - Warning state (amber)
+- `--color-dev-accent` - Dev panel accent (violet)
+- `--color-status-yellow` - Status dot yellow (#eab308)
+- `--color-status-gray` - Status dot gray (#6b7280)
+- `--color-badge-neutral` - Neutral badge text
+- `--color-badge-neutral-bg` - Neutral badge background
 
 ### Opacity Variants
 - `--color-success-bg-light` - Success background (10% opacity)
@@ -63,11 +70,14 @@ Micro spacing:
 ## Typography Tokens
 
 ### Font Sizes
+- `--font-size-2xs` - 10px
 - `--font-size-xs` - 11px
 - `--font-size-sm` - 12px
 - `--font-size-base` - 13px
 - `--font-size-md` - 14px
 - `--font-size-lg` - 15px
+- `--font-size-xl` - 16px
+- `--font-size-2xl` - 24px
 
 ### Font Weights
 - `--font-weight-normal` - 400

--- a/src/renderer/components/dev/DevPanel.module.scss
+++ b/src/renderer/components/dev/DevPanel.module.scss
@@ -23,8 +23,8 @@
     }
 
     &:checked {
-      background: #8b5cf6;
-      border-color: #8b5cf6;
+      background: var(--color-dev-accent);
+      border-color: var(--color-dev-accent);
 
       &::after {
         content: "";
@@ -49,11 +49,11 @@
 }
 
 .clearAllBtn {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   background: none;
-  border: 1px solid #ef4444;
+  border: 1px solid var(--color-error);
   border-radius: var(--radius-md);
-  color: #ef4444;
+  color: var(--color-error);
   font-size: var(--font-size-xs, 12px);
   cursor: pointer;
   transition: all 150ms ease;
@@ -61,7 +61,7 @@
   flex-shrink: 0;
 
   &:hover {
-    background: #ef4444;
+    background: var(--color-error);
     color: white;
   }
 }
@@ -124,14 +124,14 @@
   font-size: var(--font-size-sm, 13px);
   font-family: inherit;
   min-width: 0;
-  padding: 2px 0;
+  padding: var(--spacing-half) 0;
 
   &::placeholder {
     color: var(--color-text-tertiary);
   }
 
   &:focus {
-    border-bottom-color: #8b5cf6;
+    border-bottom-color: var(--color-dev-accent);
   }
 }
 
@@ -140,8 +140,8 @@
   border: none;
   color: var(--color-text-tertiary);
   cursor: pointer;
-  font-size: 14px;
-  padding: 0 4px;
+  font-size: var(--font-size-md);
+  padding: 0 var(--spacing-1);
   line-height: 1;
 
   &:hover {
@@ -150,10 +150,10 @@
 }
 
 .highlight {
-  background: color-mix(in srgb, #8b5cf6 25%, transparent);
+  background: color-mix(in srgb, var(--color-dev-accent) 25%, transparent);
   color: inherit;
   border-radius: 2px;
-  padding: 0 2px;
+  padding: 0 var(--spacing-half);
 }
 
 /* ── Presets ─────────────────────────────────────────────────────── */
@@ -175,7 +175,7 @@
 }
 
 .presetBtn {
-  padding: 3px 10px;
+  padding: var(--spacing-0-75) var(--spacing-2-5);
   background: none;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -186,19 +186,19 @@
   white-space: nowrap;
 
   &:hover {
-    border-color: #8b5cf6;
-    color: #8b5cf6;
-    background: color-mix(in srgb, #8b5cf6 8%, transparent);
+    border-color: var(--color-dev-accent);
+    color: var(--color-dev-accent);
+    background: color-mix(in srgb, var(--color-dev-accent) 8%, transparent);
   }
 }
 
 .presetBtnActive {
-  border-color: #8b5cf6;
-  color: #8b5cf6;
-  background: color-mix(in srgb, #8b5cf6 12%, transparent);
+  border-color: var(--color-dev-accent);
+  color: var(--color-dev-accent);
+  background: color-mix(in srgb, var(--color-dev-accent) 12%, transparent);
 
   &:hover {
-    background: color-mix(in srgb, #8b5cf6 6%, transparent);
+    background: color-mix(in srgb, var(--color-dev-accent) 6%, transparent);
   }
 }
 
@@ -217,7 +217,7 @@
 }
 
 .cardOverridden {
-  border-color: color-mix(in srgb, #8b5cf6 35%, var(--color-border));
+  border-color: color-mix(in srgb, var(--color-dev-accent) 35%, var(--color-border));
 }
 
 .cardFullWidth {
@@ -245,9 +245,9 @@
   flex-shrink: 0;
 
   &:hover {
-    border-color: #8b5cf6;
-    color: #8b5cf6;
-    background: color-mix(in srgb, #8b5cf6 8%, transparent);
+    border-color: var(--color-dev-accent);
+    color: var(--color-dev-accent);
+    background: color-mix(in srgb, var(--color-dev-accent) 8%, transparent);
   }
 }
 
@@ -257,7 +257,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 0;
+  padding: var(--spacing-1-5) 0;
   font-size: var(--font-size-base, 14px);
   border-bottom: 1px solid var(--color-border);
   min-height: 34px;
@@ -273,7 +273,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #8b5cf6;
+  background: var(--color-dev-accent);
   margin-right: 6px;
   flex-shrink: 0;
   vertical-align: middle;
@@ -307,7 +307,7 @@
 }
 
 .pathValue {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   opacity: 0.7;
   word-break: break-all;
 }
@@ -322,10 +322,10 @@
   flex-shrink: 0;
 }
 
-.green { background: #22c55e; }
-.yellow { background: #eab308; }
-.red { background: #ef4444; }
-.gray { background: #6b7280; }
+.green { background: var(--color-success); }
+.yellow { background: var(--color-status-yellow); }
+.red { background: var(--color-error); }
+.gray { background: var(--color-status-gray); }
 
 .refreshBtn {
   display: flex;
@@ -355,8 +355,8 @@
 
 .overrideSelect {
   appearance: none;
-  padding: 4px 18px 4px 6px;
-  font-size: 11px;
+  padding: var(--spacing-1) calc(var(--spacing-3) + var(--spacing-1-5)) var(--spacing-1) var(--spacing-1-5);
+  font-size: var(--font-size-xs);
   font-family: var(--font-mono, monospace);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -380,10 +380,10 @@
 }
 
 .overrideActive {
-  border-color: #8b5cf6;
-  background-color: color-mix(in srgb, #8b5cf6 12%, var(--color-bg-input));
+  border-color: var(--color-dev-accent);
+  background-color: color-mix(in srgb, var(--color-dev-accent) 12%, var(--color-bg-input));
   color: var(--color-text-primary);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .rangeRow {
@@ -394,11 +394,11 @@
 
 .overrideRange {
   width: 80px;
-  accent-color: #8b5cf6;
+  accent-color: var(--color-dev-accent);
 }
 
 .rangeValue {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-family: var(--font-mono, monospace);
   color: var(--color-text-primary);
   min-width: 32px;
@@ -410,14 +410,14 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   color: var(--color-text-tertiary);
-  font-size: 10px;
-  padding: 0 4px;
+  font-size: var(--font-size-2xs);
+  padding: 0 var(--spacing-1);
   cursor: pointer;
   line-height: 1.4;
 
   &:hover {
-    border-color: #ef4444;
-    color: #ef4444;
+    border-color: var(--color-error);
+    color: var(--color-error);
   }
 }
 
@@ -426,8 +426,8 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   color: var(--color-text-secondary);
-  font-size: 11px;
-  padding: 1px 8px;
+  font-size: var(--font-size-xs);
+  padding: 1px var(--spacing-2);
   cursor: pointer;
 
   &:hover {
@@ -441,7 +441,7 @@
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-family: var(--font-mono, monospace);
 
   input[type="checkbox"] {
@@ -461,14 +461,14 @@
     }
 
     &:checked {
-      background: #8b5cf6;
-      border-color: #8b5cf6;
+      background: var(--color-dev-accent);
+      border-color: var(--color-dev-accent);
 
       &::after {
         content: "";
         position: absolute;
         left: 3px;
-        top: 0px;
+        top: 0;
         width: 4px;
         height: 7px;
         border: solid white;
@@ -509,7 +509,7 @@
     font-family: var(--font-mono, monospace);
     font-style: normal;
     background: var(--color-bg-hover);
-    padding: 0 4px;
+    padding: 0 var(--spacing-1);
     border-radius: 3px;
   }
 }

--- a/src/renderer/components/dictionary/DictionaryPanel.module.scss
+++ b/src/renderer/components/dictionary/DictionaryPanel.module.scss
@@ -108,7 +108,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 6px;
+  padding: var(--spacing-1) var(--spacing-1-5);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg-root);
@@ -128,7 +128,7 @@
 }
 
 .pageSizeSelect {
-  padding: 3px 4px;
+  padding: var(--spacing-0-75) var(--spacing-1);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg-root);

--- a/src/renderer/components/general/GeneralPanel.module.scss
+++ b/src/renderer/components/general/GeneralPanel.module.scss
@@ -265,13 +265,19 @@
   }
 }
 
-@keyframes flashHighlight {
-  0%, 100% { box-shadow: none; }
-  50% { box-shadow: 0 0 0 2px var(--color-accent); }
+@keyframes flash-highlight {
+  0%,
+  100% {
+    box-shadow: none;
+  }
+
+  50% {
+    box-shadow: 0 0 0 2px var(--color-accent);
+  }
 }
 
 .flash {
-  animation: flashHighlight 0.35s ease 1;
+  animation: flash-highlight 0.35s ease 1;
   border-radius: var(--radius-md);
 }
 
@@ -528,26 +534,89 @@
   }
 }
 
-@keyframes hudMorph {
-  0%, 35% { width: 10px; height: 10px; border-radius: 50%; background: var(--color-text-tertiary); border-color: transparent; }
-  45%, 85% { width: 24px; height: 6px; border-radius: 3px; background: var(--color-text-quaternary, var(--color-border-hover)); border-color: var(--color-border); }
-  95%, 100% { width: 10px; height: 10px; border-radius: 50%; background: var(--color-text-tertiary); border-color: transparent; }
+@keyframes hud-morph {
+  0%,
+  35% {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--color-text-tertiary);
+    border-color: transparent;
+  }
+
+  45%,
+  85% {
+    width: 24px;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--color-text-quaternary, var(--color-border-hover));
+    border-color: var(--color-border);
+  }
+
+  95%,
+  100% {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--color-text-tertiary);
+    border-color: transparent;
+  }
 }
 
 .previewHudAnimated {
-  animation: hudMorph 4s ease-in-out infinite;
+  animation: hud-morph 4s ease-in-out infinite;
 }
 
 // HUD position classes (9 positions)
-.previewHud_top_left { top: 10px; left: 10px; }
-.previewHud_top_center { top: 10px; left: 50%; transform: translateX(-50%); }
-.previewHud_top_right { top: 10px; right: 10px; }
-.previewHud_center_left { top: 50%; left: 10px; transform: translateY(-50%); }
-.previewHud_center_center { top: 50%; left: 50%; transform: translate(-50%, -50%); }
-.previewHud_center_right { top: 50%; right: 10px; transform: translateY(-50%); }
-.previewHud_bottom_left { bottom: 16px; left: 10px; }
-.previewHud_bottom_center { bottom: 16px; left: 50%; transform: translateX(-50%); }
-.previewHud_bottom_right { bottom: 16px; right: 10px; }
+.previewHud_top_left {
+  top: 10px;
+  left: 10px;
+}
+
+.previewHud_top_center {
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.previewHud_top_right {
+  top: 10px;
+  right: 10px;
+}
+
+.previewHud_center_left {
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
+}
+
+.previewHud_center_center {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.previewHud_center_right {
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+}
+
+.previewHud_bottom_left {
+  bottom: 16px;
+  left: 10px;
+}
+
+.previewHud_bottom_center {
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.previewHud_bottom_right {
+  bottom: 16px;
+  right: 10px;
+}
 
 // Overlay preview pill — positioned via classes
 .previewOverlay {
@@ -572,15 +641,55 @@
 }
 
 // Overlay position classes (9 positions)
-.previewOverlay_top_left { top: 8px; left: 10px; }
-.previewOverlay_top_center { top: 8px; left: 50%; transform: translateX(-50%); }
-.previewOverlay_top_right { top: 8px; right: 10px; }
-.previewOverlay_center_left { top: 50%; left: 10px; transform: translateY(-50%); }
-.previewOverlay_center_center { top: 50%; left: 50%; transform: translate(-50%, -50%); }
-.previewOverlay_center_right { top: 50%; right: 10px; transform: translateY(-50%); }
-.previewOverlay_bottom_left { bottom: 8px; left: 10px; }
-.previewOverlay_bottom_center { bottom: 8px; left: 50%; transform: translateX(-50%); }
-.previewOverlay_bottom_right { bottom: 8px; right: 10px; }
+.previewOverlay_top_left {
+  top: 8px;
+  left: 10px;
+}
+
+.previewOverlay_top_center {
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.previewOverlay_top_right {
+  top: 8px;
+  right: 10px;
+}
+
+.previewOverlay_center_left {
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
+}
+
+.previewOverlay_center_center {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.previewOverlay_center_right {
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+}
+
+.previewOverlay_bottom_left {
+  bottom: 8px;
+  left: 10px;
+}
+
+.previewOverlay_bottom_center {
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.previewOverlay_bottom_right {
+  bottom: 8px;
+  right: 10px;
+}
 
 .speechHint {
   margin-top: var(--spacing-2);

--- a/src/renderer/components/layout/Sidebar.module.scss
+++ b/src/renderer/components/layout/Sidebar.module.scss
@@ -22,11 +22,11 @@
 
   .navItem {
     justify-content: center;
-    padding: 6px;
+    padding: var(--spacing-1-5);
   }
 
   .bottom {
-    padding: 8px 4px;
+    padding: var(--spacing-2) var(--spacing-1);
   }
 }
 
@@ -35,7 +35,7 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  padding: 38px 8px 8px;
+  padding: calc(var(--spacing-8) + var(--spacing-1-5)) var(--spacing-2) var(--spacing-2);
   -webkit-app-region: drag;
 }
 
@@ -98,7 +98,7 @@
 .nav {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
 
   &::-webkit-scrollbar {
     width: 4px;
@@ -123,7 +123,7 @@
   color: var(--color-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   margin-bottom: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -135,7 +135,7 @@
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 6px 8px;
+  padding: var(--spacing-1-5) var(--spacing-2);
   border-radius: var(--radius-md);
   background: none;
   border: none;
@@ -197,12 +197,12 @@
 
 .bottom {
   margin-top: auto;
-  padding: 8px;
+  padding: var(--spacing-2);
 }
 
 .updateLabel {
   margin-left: auto;
-  padding: 2px 8px;
+  padding: var(--spacing-half) var(--spacing-2);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
   color: var(--color-accent);
@@ -232,20 +232,20 @@
 
 /* Dev Panel button */
 .devItem {
-  background: color-mix(in srgb, #8b5cf6 8%, transparent);
-  border: 1px solid color-mix(in srgb, #8b5cf6 20%, transparent);
-  color: color-mix(in srgb, #8b5cf6 70%, var(--color-text-secondary));
+  background: color-mix(in srgb, var(--color-dev-accent) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-dev-accent) 20%, transparent);
+  color: color-mix(in srgb, var(--color-dev-accent) 70%, var(--color-text-secondary));
 
   &:hover {
-    background: color-mix(in srgb, #8b5cf6 15%, transparent);
-    border-color: color-mix(in srgb, #8b5cf6 30%, transparent);
+    background: color-mix(in srgb, var(--color-dev-accent) 15%, transparent);
+    border-color: color-mix(in srgb, var(--color-dev-accent) 30%, transparent);
   }
 }
 
 .devItemActive {
-  background: color-mix(in srgb, #8b5cf6 18%, transparent);
-  border-color: color-mix(in srgb, #8b5cf6 35%, transparent);
-  color: color-mix(in srgb, #8b5cf6 85%, var(--color-text-primary));
+  background: color-mix(in srgb, var(--color-dev-accent) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-dev-accent) 35%, transparent);
+  color: color-mix(in srgb, var(--color-dev-accent) 85%, var(--color-text-primary));
 }
 
 .warningDot {
@@ -255,7 +255,7 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #ef4444;
+  background: var(--color-error);
 }
 
 .devHidden {

--- a/src/renderer/components/layout/Titlebar.module.scss
+++ b/src/renderer/components/layout/Titlebar.module.scss
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: flex-end;
   height: 48px;
-  padding: 0 12px;
+  padding: 0 var(--spacing-3);
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg-root);
   -webkit-app-region: drag;
@@ -46,7 +46,7 @@
   align-items: center;
   gap: 4px;
   height: 28px;
-  padding: 0 8px;
+  padding: 0 var(--spacing-2);
   background: none;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -79,7 +79,7 @@
   align-items: center;
   gap: 4px;
   height: 28px;
-  padding: 0 8px;
+  padding: 0 var(--spacing-2);
   color: var(--color-text-tertiary);
   font-size: var(--font-size-sm);
   white-space: nowrap;
@@ -105,7 +105,7 @@
   width: 0;
   height: 22px;
   padding: 0;
-  background: #dc2626;
+  background: var(--color-error-hover);
   border: none;
   border-radius: var(--radius-md);
   color: white;
@@ -117,7 +117,7 @@
   transition: width 150ms ease, opacity 150ms ease, margin-right 150ms ease;
 
   &:hover {
-    background: #b91c1c;
+    background: var(--color-error-active);
   }
 }
 
@@ -126,8 +126,8 @@
   display: flex;
   align-items: center;
   height: 22px;
-  padding: 0 8px;
-  background: #ef4444;
+  padding: 0 var(--spacing-2);
+  background: var(--color-error);
   border: none;
   border-radius: var(--radius-md);
   color: white;
@@ -140,7 +140,7 @@
   transition: background 150ms ease;
 
   &:hover {
-    background: #dc2626;
+    background: var(--color-error-hover);
   }
 }
 

--- a/src/renderer/components/llm/LlmPanel.module.scss
+++ b/src/renderer/components/llm/LlmPanel.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  margin-bottom: var(--spacing-4);
   padding: var(--spacing-4) var(--spacing-5);
   margin-bottom: var(--spacing-3);
   border: 1px solid var(--color-border);

--- a/src/renderer/components/onboarding/OnboardingOverlay.module.scss
+++ b/src/renderer/components/onboarding/OnboardingOverlay.module.scss
@@ -8,38 +8,42 @@
   align-items: center;
   justify-content: center;
   background: var(--color-bg-root);
-  animation: overlayExpand 400ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: overlay-expand 400ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
 .overlayClosing {
-  animation: overlayCollapse 500ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  animation: overlay-collapse 500ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
   pointer-events: none;
 }
 
-@keyframes overlayExpand {
+@keyframes overlay-expand {
   0% {
     opacity: 0;
     clip-path: circle(0% at 85% 12%);
   }
+
   30% {
     opacity: 1;
     clip-path: circle(8% at 85% 12%);
   }
+
   100% {
     opacity: 1;
     clip-path: circle(150% at 50% 50%);
   }
 }
 
-@keyframes overlayCollapse {
+@keyframes overlay-collapse {
   0% {
     opacity: 1;
     clip-path: circle(150% at 50% 50%);
   }
+
   70% {
     opacity: 1;
     clip-path: circle(8% at 85% 12%);
   }
+
   100% {
     opacity: 0;
     clip-path: circle(0% at 85% 12%);
@@ -125,7 +129,7 @@
 /* ---- Typography ---- */
 
 .title {
-  font-size: 24px;
+  font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.02em;
   color: var(--color-text-primary);
@@ -271,7 +275,7 @@
   font-weight: var(--font-weight-semibold);
   color: var(--color-accent);
   background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-  padding: 1px 6px;
+  padding: 1px var(--spacing-1-5);
   border-radius: var(--radius-full);
 }
 
@@ -321,9 +325,9 @@
   border: none;
   color: var(--color-text-tertiary);
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   line-height: 1;
-  padding: 0 2px;
+  padding: 0 var(--spacing-half);
 
   &:hover {
     color: var(--color-error);
@@ -603,25 +607,42 @@
   background: var(--color-accent);
   color: white;
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-accent) 30%, transparent);
-  animation: hudFloat 3s ease-in-out infinite;
+  animation: hud-float 3s ease-in-out infinite;
 }
 
 .hudPreviewCursor {
   position: absolute;
   right: 16px;
   bottom: 12px;
-  animation: cursorApproach 3s ease-in-out infinite;
+  animation: cursor-approach 3s ease-in-out infinite;
 }
 
-@keyframes hudFloat {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-4px); }
+@keyframes hud-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-4px);
+  }
 }
 
-@keyframes cursorApproach {
-  0% { transform: translate(12px, 8px); opacity: 0.4; }
-  50% { transform: translate(0, 0); opacity: 1; }
-  100% { transform: translate(12px, 8px); opacity: 0.4; }
+@keyframes cursor-approach {
+  0% {
+    transform: translate(12px, 8px);
+    opacity: 0.4;
+  }
+
+  50% {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(12px, 8px);
+    opacity: 0.4;
+  }
 }
 
 .hudButtonRow {

--- a/src/renderer/components/shared/forms.module.scss
+++ b/src/renderer/components/shared/forms.module.scss
@@ -17,7 +17,6 @@
 
     input[type="checkbox"] {
       appearance: none;
-      appearance: none;
       width: var(--size-icon-sm);
       height: var(--size-icon-sm);
       min-width: var(--size-icon-sm);
@@ -173,7 +172,6 @@
   }
 
   input[type="checkbox"] {
-    appearance: none;
     appearance: none;
     width: var(--size-icon-sm);
     height: var(--size-icon-sm);

--- a/src/renderer/components/transcriptions/TranscriptionsPanel.module.scss
+++ b/src/renderer/components/transcriptions/TranscriptionsPanel.module.scss
@@ -178,7 +178,7 @@
   background: var(--color-bg-root);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-base);
-  box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+  box-shadow: 0 4px 12px var(--color-shadow);
 }
 
 .overflowItem {
@@ -207,7 +207,7 @@
 
 .overflowItemDanger {
   &:hover {
-    color: var(--color-danger, #ef4444);
+    color: var(--color-error);
   }
 }
 
@@ -272,7 +272,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 6px;
+  padding: var(--spacing-1) var(--spacing-1-5);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg-root);
@@ -292,7 +292,7 @@
 }
 
 .pageSizeSelect {
-  padding: 3px 4px;
+  padding: var(--spacing-0-75) var(--spacing-1);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg-root);
@@ -326,8 +326,8 @@
   }
 
   &.confirmClear {
-    border-color: var(--color-danger, #ef4444);
-    color: var(--color-danger, #ef4444);
+    border-color: var(--color-error);
+    color: var(--color-error);
   }
 }
 
@@ -341,7 +341,7 @@
   padding-left: var(--spacing-3);
 }
 
-@keyframes retryPulse {
+@keyframes retry-pulse {
   0%,
   100% {
     opacity: 1;
@@ -353,7 +353,7 @@
 }
 
 .entryRetrying {
-  animation: retryPulse 1.5s ease-in-out infinite;
+  animation: retry-pulse 1.5s ease-in-out infinite;
   pointer-events: none;
 }
 

--- a/src/renderer/components/ui/CustomSelect.module.scss
+++ b/src/renderer/components/ui/CustomSelect.module.scss
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--color-bg-input);
   border: 1px solid var(--color-border);
   border-radius: 6px;
@@ -49,7 +49,7 @@
   padding: var(--spacing-1) 0;
   max-height: 240px;
   overflow-y: auto;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px var(--color-shadow);
 
   &::-webkit-scrollbar {
     width: 6px;
@@ -91,7 +91,7 @@
 
 .optionLabel {
   flex: 1;
-  padding: 7px 12px;
+  padding: 7px var(--spacing-3);
   background: none;
   border: none;
   color: inherit;

--- a/src/renderer/components/ui/ModelSelector.module.scss
+++ b/src/renderer/components/ui/ModelSelector.module.scss
@@ -26,7 +26,6 @@
 
   input[type="radio"] {
     appearance: none;
-    appearance: none;
     width: var(--size-icon-sm);
     height: var(--size-icon-sm);
     border: 1px solid var(--color-border-hover);

--- a/src/renderer/components/ui/PermissionRequest.module.scss
+++ b/src/renderer/components/ui/PermissionRequest.module.scss
@@ -58,12 +58,7 @@
   }
 
   &.setupBadge {
-    color: #6b7280;
-    background: #f3f4f6;
-
-    :global(.dark) & {
-      color: #9ca3af;
-      background: #374151;
-    }
+    color: var(--color-badge-neutral);
+    background: var(--color-badge-neutral-bg);
   }
 }

--- a/src/renderer/components/ui/SaveToast.module.scss
+++ b/src/renderer/components/ui/SaveToast.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 8px;
+  padding: var(--spacing-0-75) var(--spacing-2);
   margin-right: var(--spacing-2);
   background: var(--color-bg-card);
   color: var(--color-text-secondary);

--- a/src/renderer/components/ui/WarningBadge.module.scss
+++ b/src/renderer/components/ui/WarningBadge.module.scss
@@ -5,11 +5,11 @@
   width: 16px;
   height: 16px;
   margin-left: 6px;
-  background-color: #ef4444;
+  background-color: var(--color-error);
   color: white;
   border-radius: 50%;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   line-height: 1;
   cursor: help;
 }

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -18,7 +18,14 @@
   --color-success: #22c55e;
   --color-checkmark: #6366f1;
   --color-error: #ef4444;
+  --color-error-hover: #dc2626;
+  --color-error-active: #b91c1c;
   --color-warning: #f59e0b;
+  --color-dev-accent: #8b5cf6;
+  --color-status-yellow: #eab308;
+  --color-status-gray: #6b7280;
+  --color-badge-neutral: #9ca3af;
+  --color-badge-neutral-bg: #374151;
 
   /* Spacing scale */
   --spacing-0: 0;
@@ -37,11 +44,14 @@
   --spacing-2-5: 10px;
 
   /* Typography scale */
+  --font-size-2xs: 10px;
   --font-size-xs: 11px;
   --font-size-sm: 12px;
   --font-size-base: 13px;
   --font-size-md: 14px;
   --font-size-lg: 15px;
+  --font-size-xl: 16px;
+  --font-size-2xl: 24px;
 
   /* Font weights */
   --font-weight-normal: 400;
@@ -114,7 +124,14 @@
   --color-success: #22c55e;
   --color-checkmark: #6366f1;
   --color-error: #ef4444;
+  --color-error-hover: #dc2626;
+  --color-error-active: #b91c1c;
   --color-warning: #f59e0b;
+  --color-dev-accent: #8b5cf6;
+  --color-status-yellow: #eab308;
+  --color-status-gray: #6b7280;
+  --color-badge-neutral: #9ca3af;
+  --color-badge-neutral-bg: #374151;
 
   /* Spacing scale duplicates for tree-shaking workaround */
   --spacing-0: 0;
@@ -131,11 +148,14 @@
   --spacing-2-5: 10px;
 
   /* Typography duplicates */
+  --font-size-2xs: 10px;
   --font-size-xs: 11px;
   --font-size-sm: 12px;
   --font-size-base: 13px;
   --font-size-md: 14px;
   --font-size-lg: 15px;
+  --font-size-xl: 16px;
+  --font-size-2xl: 24px;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
@@ -162,7 +182,6 @@
 
   /* Shadow and animation duplicates */
   --shadow-toast: 0 4px 12px rgb(0 0 0 / 30%);
-  --color-checkmark: #6366f1;
   --duration-fast: 150ms;
   --duration-base: 200ms;
   --duration-slow: 300ms;
@@ -202,7 +221,14 @@
   --color-success: #16a34a;
   --color-checkmark: #4f46e5;
   --color-error: #dc2626;
+  --color-error-hover: #dc2626;
+  --color-error-active: #b91c1c;
   --color-warning: #d97706;
+  --color-dev-accent: #8b5cf6;
+  --color-status-yellow: #eab308;
+  --color-status-gray: #6b7280;
+  --color-badge-neutral: #6b7280;
+  --color-badge-neutral-bg: #f3f4f6;
 
   /* Color opacity variants - light theme (same values work) */
   --color-success-bg-light: rgb(34 197 94 / 10%);
@@ -269,10 +295,22 @@ input[type="text"] {
   user-select: text;
   -webkit-user-select: text;
 
-  &:hover { border-color: var(--color-border-hover); }
-  &:focus { border-color: var(--color-border-focus); }
-  &[readonly] { color: var(--color-text-secondary); cursor: default; }
-  &::placeholder { color: var(--color-text-muted); }
+  &:hover {
+    border-color: var(--color-border-hover);
+  }
+
+  &:focus {
+    border-color: var(--color-border-focus);
+  }
+
+  &[readonly] {
+    color: var(--color-text-secondary);
+    cursor: default;
+  }
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
 }
 
 /* ---- Select ---- */
@@ -290,15 +328,19 @@ select {
   transition: border-color 150ms ease;
   outline: none;
   appearance: none;
-  appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23737373' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 12px center;
   padding-right: 32px;
   cursor: pointer;
 
-  &:hover { border-color: var(--color-border-hover); }
-  &:focus { border-color: var(--color-border-focus); }
+  &:hover {
+    border-color: var(--color-border-hover);
+  }
+
+  &:focus {
+    border-color: var(--color-border-focus);
+  }
 }
 
 /* ---- Content area ---- */
@@ -308,10 +350,22 @@ select {
   overflow-y: scroll;
   padding: 24px;
 
-  &::-webkit-scrollbar { width: 6px; }
-  &::-webkit-scrollbar-track { background: var(--color-bg-hover); }
-  &::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 3px; }
-  &::-webkit-scrollbar-thumb:hover { background: var(--color-border-hover); }
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--color-bg-hover);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--color-border-hover);
+  }
 }
 
 /* ---- Animations ---- */


### PR DESCRIPTION
## Summary

- Fix all 61+ stylelint errors across 15 SCSS component files and `globals.css`
- Fix all `check:tokens` violations by replacing hardcoded hex colors, font-sizes, padding values, and font-weights with design token `var()` references
- Add `lint:css` and `check:tokens` steps to CI workflow with outcomes reported in the PR summary comment
- Add new design tokens: `--font-size-2xs`, `--font-size-xl`, `--font-size-2xl`, `--color-dev-accent`, `--color-error-hover`, `--color-error-active`, `--color-status-yellow`, `--color-status-gray`, `--color-badge-neutral`, `--color-badge-neutral-bg`
- Update stylelint config to support CSS Modules (`composes`, `:global`), Electron vendor prefixes (`-webkit-user-select`, `-webkit-backdrop-filter`, `-webkit-app-region`), and `color-mix()` percentages in border values

## Visual Regression Checklist

> All changes are token-only replacements — no visual differences expected.
> Check each screen in **both dark and light themes**.

### Always visible

- [x] **Sidebar** — nav items, active state, category labels, checkmark indicators, warning dots, dev-mode accent colors
- [x] **Titlebar** — close/minimize/maximize buttons, update button (normal + ready + downloading states), action buttons

### Settings tabs

- [x] **General** — HUD preview grid (9 positions + 9 overlay positions), flash-highlight animation, theme selector, all `CustomSelect` dropdowns (language, speech languages, position, audio cues, display)
- [x] **Speech** — `ModelSelector` (model cards, download progress), whisper test section
- [x] **AI Enhancement** — provider `CustomSelect` dropdown, form fields, connection test section, status box, inline tabs
- [x] **Dictionary** — term list, add term form, pagination `CustomSelect`, term budget indicator, text selection (webkit)
- [x] **Transcriptions** — transcription list, search, pagination `CustomSelect`, copy/delete buttons, danger/error states (red badges)
- [x] **Permissions** — permission rows with granted (green) / missing (amber) / setup (neutral gray) badges
- [x] **Shortcuts** — form field layouts (shared `forms.module.scss`)

### Onboarding wizard (trigger via General > "Re-run setup")

- [x] **Step 1 — Welcome** — overlay expand/collapse animations
- [x] **Step 2 — Model Download** — `ModelSelector` component
- [x] **Step 3 — Permissions** — `PermissionRequest` rows with badge states
- [x] **Step 4 — Shortcut Learning** — cursor-approach animation
- [x] **Step 5 — Try It Out** — HUD float animation
- [x] **Step 6 — HUD Demo** — hud-morph animation, position previews
- [x] **Step 7 — LLM Introduction** — text and layout
- [x] **Step 8 — Done** — completion state

### Dev Panel (dev mode only)

- [x] **Panel header** — master toggle checkbox, clear all button, search input
- [x] **State rows** — status dots (green/yellow/red/gray), override controls (selects, ranges, checkboxes)
- [x] **Presets** — preset buttons (normal + active + hover), accent colors throughout
- [x] **Override indicators** — override dot, overridden card border, restore buttons

### Shared UI components (appear across multiple screens)

- [x] **CustomSelect** — trigger, dropdown, options, hover/focus states, multi-select chips, search box, dividers, preview button
- [x] **SaveToast** — appears in titlebar area after saving any setting
- [x] **WarningBadge** — appears in sidebar next to incomplete setup items

## Automated checks

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run lint:css` — 0 errors (was 61+)
- [x] `npm run check:tokens` — all green (was 4 failing categories)
- [x] `npx vitest run` — 494 tests passed