### PR TITLE
chore: update website URL to usevox.app

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 github: [rodrigoluizs, guicheffer]
 buy_me_a_coffee: rodrigoluizs
-custom: ["https://app-vox.github.io/vox/"]
+custom: ["https://usevox.app/"]

--- a/src/renderer/components/about/AboutPanel.tsx
+++ b/src/renderer/components/about/AboutPanel.tsx
@@ -74,7 +74,7 @@ export function AboutPanel() {
             alt="Vox"
             className={styles.aboutLogo}
             draggable={false}
-            onClick={() => window.voxApi.shell.openExternal("https://app-vox.github.io/vox/")}
+            onClick={() => window.voxApi.shell.openExternal("https://usevox.app/")}
             title={t("sidebar.visitWebsite")}
           />
         )}

--- a/src/renderer/components/layout/Sidebar.tsx
+++ b/src/renderer/components/layout/Sidebar.tsx
@@ -22,7 +22,7 @@ import { computeLlmConfigHash } from "../../../shared/llm-config-hash";
 import { useDevOverrideValue, useDevOverridesActive } from "../../hooks/use-dev-override";
 import styles from "./Sidebar.module.scss";
 
-const VOX_WEBSITE_URL = "https://app-vox.github.io/vox/";
+const VOX_WEBSITE_URL = "https://usevox.app/";
 
 interface NavItemDef {
   id: string;

--- a/src/renderer/components/onboarding/steps/DoneStep.tsx
+++ b/src/renderer/components/onboarding/steps/DoneStep.tsx
@@ -27,7 +27,7 @@ export function DoneStep({ onComplete, onExploreSettings }: DoneStepProps) {
 
       <a
         className={styles.skipLink}
-        href="https://app-vox.github.io/vox/"
+        href="https://usevox.app/"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Sieh dir den Transkriptionen-Tab für deinen vollständigen durchsuchbaren Verlauf an",
   "onboarding.done.tipDictionary": "Füge Namen und Begriffe zum Wörterbuch hinzu, um die Genauigkeit zu verbessern",
   "onboarding.done.tipAi": "Aktiviere KI-Verbesserung in den Einstellungen, um Grammatik automatisch zu korrigieren",
-  "onboarding.done.visitWebsite": "Mehr erfahren auf app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Mehr erfahren auf usevox.app",
   "onboarding.hud.previewLabel": "So werden Sie es sehen:",
   "menu.file": "Datei",
   "menu.view": "Ansicht",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -431,7 +431,7 @@
   "onboarding.done.tipTranscriptions": "Check the Transcriptions tab for your full searchable history",
   "onboarding.done.tipDictionary": "Add names and terms to the Dictionary to improve accuracy",
   "onboarding.done.tipAi": "Enable AI Enhancement in Settings to fix grammar automatically",
-  "onboarding.done.visitWebsite": "Learn more at app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Learn more at usevox.app",
   "onboarding.done.startUsing": "Start Using Vox",
   "onboarding.done.exploreSettings": "Explore Settings",
   "onboarding.navigation.back": "Back",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Revisa la pestaña Transcripciones para tu historial completo con búsqueda",
   "onboarding.done.tipDictionary": "Añade nombres y términos al Diccionario para mejorar la precisión",
   "onboarding.done.tipAi": "Activa la Mejora con IA en Configuración para corregir gramática automáticamente",
-  "onboarding.done.visitWebsite": "Más información en app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Más información en usevox.app",
   "onboarding.hud.previewLabel": "Así es como lo verás:",
   "menu.file": "Archivo",
   "menu.view": "Ver",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Consultez l'onglet Transcriptions pour votre historique complet avec recherche",
   "onboarding.done.tipDictionary": "Ajoutez des noms et des termes au Dictionnaire pour améliorer la précision",
   "onboarding.done.tipAi": "Activez l'Amélioration IA dans les Réglages pour corriger la grammaire automatiquement",
-  "onboarding.done.visitWebsite": "En savoir plus sur app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "En savoir plus sur usevox.app",
   "onboarding.hud.previewLabel": "Voici comment vous le verrez :",
   "menu.file": "Fichier",
   "menu.view": "Affichage",

--- a/src/shared/i18n/locales/it.json
+++ b/src/shared/i18n/locales/it.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Consulta la scheda Trascrizioni per la cronologia completa con ricerca",
   "onboarding.done.tipDictionary": "Aggiungi nomi e termini al Dizionario per migliorare la precisione",
   "onboarding.done.tipAi": "Attiva il Miglioramento IA nelle Impostazioni per correggere automaticamente la grammatica",
-  "onboarding.done.visitWebsite": "Scopri di più su app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Scopri di più su usevox.app",
   "onboarding.hud.previewLabel": "Ecco come lo vedrai:",
   "menu.file": "File",
   "menu.view": "Vista",

--- a/src/shared/i18n/locales/pl.json
+++ b/src/shared/i18n/locales/pl.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Sprawdź zakładkę Transkrypcje, aby zobaczyć pełną historię z wyszukiwaniem",
   "onboarding.done.tipDictionary": "Dodaj imiona i terminy do Słownika, aby poprawić dokładność",
   "onboarding.done.tipAi": "Włącz Ulepszanie AI w Ustawieniach, aby automatycznie poprawiać gramatykę",
-  "onboarding.done.visitWebsite": "Dowiedz się więcej na app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Dowiedz się więcej na usevox.app",
   "onboarding.hud.previewLabel": "Tak to będzie wyglądać:",
   "menu.file": "Plik",
   "menu.view": "Widok",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Confira a aba Transcrições para seu histórico completo com busca",
   "onboarding.done.tipDictionary": "Adicione nomes e termos ao Dicionário para melhorar a precisão",
   "onboarding.done.tipAi": "Ative o Aprimoramento com IA nas Configurações para corrigir gramática automaticamente",
-  "onboarding.done.visitWebsite": "Saiba mais em app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Saiba mais em usevox.app",
   "onboarding.hud.previewLabel": "É assim que você vai ver:",
   "menu.file": "Arquivo",
   "menu.view": "Visualizar",

--- a/src/shared/i18n/locales/pt-PT.json
+++ b/src/shared/i18n/locales/pt-PT.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Consulte o separador Transcrições para o seu histórico completo com pesquisa",
   "onboarding.done.tipDictionary": "Adicione nomes e termos ao Dicionário para melhorar a precisão",
   "onboarding.done.tipAi": "Ative o Melhoramento com IA nas Definições para corrigir gramática automaticamente",
-  "onboarding.done.visitWebsite": "Saiba mais em app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Saiba mais em usevox.app",
   "onboarding.hud.previewLabel": "É assim que vai ver:",
   "menu.file": "Ficheiro",
   "menu.view": "Ver",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Проверьте вкладку Транскрипции для полной истории с поиском",
   "onboarding.done.tipDictionary": "Добавьте имена и термины в Словарь для повышения точности",
   "onboarding.done.tipAi": "Включите Улучшение ИИ в Настройках для автоматического исправления грамматики",
-  "onboarding.done.visitWebsite": "Узнайте больше на app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Узнайте больше на usevox.app",
   "onboarding.hud.previewLabel": "Вот как это будет выглядеть:",
   "menu.file": "Файл",
   "menu.view": "Вид",

--- a/src/shared/i18n/locales/tr.json
+++ b/src/shared/i18n/locales/tr.json
@@ -455,7 +455,7 @@
   "onboarding.done.tipTranscriptions": "Tam aranabilir geçmişiniz için Yazıya Dökümler sekmesine bakın",
   "onboarding.done.tipDictionary": "Doğruluğu artırmak için Sözlüğe isimler ve terimler ekleyin",
   "onboarding.done.tipAi": "Dilbilgisini otomatik düzeltmek için Ayarlarda Yapay Zeka İyileştirmeyi etkinleştirin",
-  "onboarding.done.visitWebsite": "Daha fazla bilgi için app-vox.github.io/vox",
+  "onboarding.done.visitWebsite": "Daha fazla bilgi için usevox.app",
   "onboarding.hud.previewLabel": "Böyle görünecek:",
   "menu.file": "Dosya",
   "menu.view": "Görünüm",


### PR DESCRIPTION
## Summary
- Replace all references from `app-vox.github.io/vox` to `usevox.app` across the codebase
- Updated source code (Sidebar, AboutPanel, DoneStep onboarding)
- Updated GitHub FUNDING.yml
- Updated all 10 i18n locale files

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 494 tests pass
- [x] i18n test specifically passes (all locales have matching keys)
- [x] Grep confirms zero remaining references to old URL