### PR TITLE
feat(ui): add collapsible section for transcription preferences

### DIFF
--- a/src/renderer/components/general/GeneralPanel.tsx
+++ b/src/renderer/components/general/GeneralPanel.tsx
@@ -17,6 +17,7 @@ import buttons from "../shared/buttons.module.scss";
 import styles from "./GeneralPanel.module.scss";
 
 const DISPLAY_COLLAPSED_KEY = "vox:display-collapsed";
+const TEXT_PROCESSING_COLLAPSED_KEY = "vox:text-processing-collapsed";
 const HUD_BANNER_DISMISSED_KEY = "vox:hud-banner-dismissed";
 const SHORTCUTS_BANNER_DISMISSED_KEY = "vox:shortcuts-banner-dismissed";
 const VISITED_SHORTCUTS_KEY = "vox:visited-shortcuts";
@@ -159,6 +160,7 @@ export function GeneralPanel() {
   ];
 
   const [displayCollapsed, setDisplayCollapsed] = useState(() => localStorage.getItem(DISPLAY_COLLAPSED_KEY) !== "false");
+  const [textProcessingCollapsed, setTextProcessingCollapsed] = useState(() => localStorage.getItem(TEXT_PROCESSING_COLLAPSED_KEY) !== "false");
   const [perfCollapsed, setPerfCollapsed] = useState(true);
   const [hudBannerDismissed, setHudBannerDismissed] = useState(() => localStorage.getItem(HUD_BANNER_DISMISSED_KEY) === "true");
   const [shortcutsBannerDismissedLocal, setShortcutsBannerDismissed] = useState(() =>
@@ -736,54 +738,77 @@ export function GeneralPanel() {
 
       {/* Text processing */}
       <div className={card.card}>
-        <div className={card.body}>
-          <label className={styles.checkboxRow}>
-            <input
-              type="checkbox"
-              checked={config.finishWithPeriod ?? true}
-              onChange={async () => {
-                updateConfig({ finishWithPeriod: !(config.finishWithPeriod ?? true) });
-                await saveConfig(false);
-                triggerToast();
-              }}
-            />
-            <div>
-              <div className={styles.checkboxLabel}>{t("whisper.finishWithPeriod")}</div>
-              <div className={styles.checkboxDesc}>{t("whisper.finishWithPeriodHint")}</div>
-            </div>
-          </label>
-          <label className={styles.checkboxRow}>
-            <input
-              type="checkbox"
-              checked={config.lowercaseStart ?? false}
-              onChange={async () => {
-                updateConfig({ lowercaseStart: !config.lowercaseStart });
-                await saveConfig(false);
-                triggerToast();
-              }}
-            />
-            <div>
-              <div className={styles.checkboxLabel}>{t("whisper.lowercaseStart")}</div>
-              <div className={styles.checkboxDesc}>{t("whisper.lowercaseStartHint")}</div>
-            </div>
-          </label>
-          <label className={`${styles.checkboxRow} ${!config.lowercaseStart ? styles.disabled : ""}`} style={{ marginLeft: 24 }}>
-            <input
-              type="checkbox"
-              disabled={!config.lowercaseStart}
-              checked={config.shiftCapitalize ?? true}
-              onChange={async () => {
-                updateConfig({ shiftCapitalize: !config.shiftCapitalize });
-                await saveConfig(false);
-                triggerToast();
-              }}
-            />
-            <div>
-              <div className={styles.checkboxLabel}>{t("whisper.shiftCapitalize")}</div>
-              <div className={styles.checkboxDesc}>{t("whisper.shiftCapitalizeHint")}</div>
-            </div>
-          </label>
-        </div>
+        <button
+          className={styles.collapsibleHeader}
+          onClick={() => {
+            setTextProcessingCollapsed((prev) => {
+              const next = !prev;
+              localStorage.setItem(TEXT_PROCESSING_COLLAPSED_KEY, String(next));
+              return next;
+            });
+          }}
+          aria-expanded={!textProcessingCollapsed}
+        >
+          <div>
+            <h2>{t("general.textProcessing.title")}</h2>
+            <p className={card.description}>{t("general.textProcessing.description")}</p>
+          </div>
+          <ChevronDownIcon
+            width={16}
+            height={16}
+            className={`${styles.collapseChevron} ${textProcessingCollapsed ? styles.collapsed : ""}`}
+          />
+        </button>
+        {!textProcessingCollapsed && (
+          <div className={card.body}>
+            <label className={styles.checkboxRow}>
+              <input
+                type="checkbox"
+                checked={config.finishWithPeriod ?? true}
+                onChange={async () => {
+                  updateConfig({ finishWithPeriod: !(config.finishWithPeriod ?? true) });
+                  await saveConfig(false);
+                  triggerToast();
+                }}
+              />
+              <div>
+                <div className={styles.checkboxLabel}>{t("whisper.finishWithPeriod")}</div>
+                <div className={styles.checkboxDesc}>{t("whisper.finishWithPeriodHint")}</div>
+              </div>
+            </label>
+            <label className={styles.checkboxRow}>
+              <input
+                type="checkbox"
+                checked={config.lowercaseStart ?? false}
+                onChange={async () => {
+                  updateConfig({ lowercaseStart: !config.lowercaseStart });
+                  await saveConfig(false);
+                  triggerToast();
+                }}
+              />
+              <div>
+                <div className={styles.checkboxLabel}>{t("whisper.lowercaseStart")}</div>
+                <div className={styles.checkboxDesc}>{t("whisper.lowercaseStartHint")}</div>
+              </div>
+            </label>
+            <label className={`${styles.checkboxRow} ${!config.lowercaseStart ? styles.disabled : ""}`} style={{ marginLeft: 24 }}>
+              <input
+                type="checkbox"
+                disabled={!config.lowercaseStart}
+                checked={config.shiftCapitalize ?? true}
+                onChange={async () => {
+                  updateConfig({ shiftCapitalize: !config.shiftCapitalize });
+                  await saveConfig(false);
+                  triggerToast();
+                }}
+              />
+              <div>
+                <div className={styles.checkboxLabel}>{t("whisper.shiftCapitalize")}</div>
+                <div className={styles.checkboxDesc}>{t("whisper.shiftCapitalizeHint")}</div>
+              </div>
+            </label>
+          </div>
+        )}
       </div>
 
       <div className={card.card}>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Klassisch",
   "general.recordingFeedback.errorSound": "Warnton",
+  "general.textProcessing.title": "Transkriptionseinstellungen",
+  "general.textProcessing.description": "Passen Sie die Formatierung des transkribierten Texts an.",
   "indicator.initializing": "Starten...",
   "ui.offlineWarning": "Sie scheinen offline zu sein. Einige Funktionen wie das Herunterladen von Modellen funktionieren möglicherweise nicht.",
   "general.permissions.title": "Berechtigungen Erteilen",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -377,6 +377,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Classic",
   "general.recordingFeedback.errorSound": "Alert sound",
+  "general.textProcessing.title": "Transcription Preferences",
+  "general.textProcessing.description": "Adjust how your transcribed text is formatted.",
   "indicator.initializing": "Starting...",
   "ui.offlineWarning": "You appear to be offline. Some features like model downloads may not work.",
   "general.shortcuts.banner.title": "Set up keyboard shortcuts",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Clásico",
   "general.recordingFeedback.errorSound": "Sonido de alerta",
+  "general.textProcessing.title": "Preferencias de transcripción",
+  "general.textProcessing.description": "Ajusta cómo se formatea el texto transcrito.",
   "indicator.initializing": "Iniciando...",
   "ui.offlineWarning": "Parece que estás sin conexión. Algunas funciones como la descarga de modelos podrían no funcionar.",
   "general.permissions.title": "Otorgar Permisos",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Classique",
   "general.recordingFeedback.errorSound": "Son d'alerte",
+  "general.textProcessing.title": "Préférences de transcription",
+  "general.textProcessing.description": "Ajustez le formatage du texte transcrit.",
   "indicator.initializing": "Démarrage...",
   "ui.offlineWarning": "Vous semblez être hors ligne. Certaines fonctionnalités comme le téléchargement de modèles pourraient ne pas fonctionner.",
   "general.permissions.title": "Accorder les Permissions",

--- a/src/shared/i18n/locales/it.json
+++ b/src/shared/i18n/locales/it.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Classico",
   "general.recordingFeedback.errorSound": "Suono di avviso",
+  "general.textProcessing.title": "Preferenze di trascrizione",
+  "general.textProcessing.description": "Regola come viene formattato il testo trascritto.",
   "indicator.initializing": "Avvio...",
   "ui.offlineWarning": "Sembra che tu sia offline. Alcune funzionalità come il download dei modelli potrebbero non funzionare.",
   "general.permissions.title": "Concedi Permessi",

--- a/src/shared/i18n/locales/pl.json
+++ b/src/shared/i18n/locales/pl.json
@@ -361,6 +361,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Klasyczne",
   "general.recordingFeedback.errorSound": "Dźwięk alertu",
+  "general.textProcessing.title": "Preferencje transkrypcji",
+  "general.textProcessing.description": "Dostosuj formatowanie transkrybowanego tekstu.",
   "indicator.initializing": "Uruchamianie...",
   "history.deleteTranscription": "Usuń transkrypcję",
   "history.status.whisperFailed": "Transkrypcja nie powiodła się",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Clássico",
   "general.recordingFeedback.errorSound": "Som de alerta",
+  "general.textProcessing.title": "Preferências de transcrição",
+  "general.textProcessing.description": "Ajuste como o texto transcrito é formatado.",
   "indicator.initializing": "Iniciando...",
   "ui.offlineWarning": "Você parece estar offline. Alguns recursos como download de modelos podem não funcionar.",
   "general.permissions.title": "Conceder Permissões",

--- a/src/shared/i18n/locales/pt-PT.json
+++ b/src/shared/i18n/locales/pt-PT.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Clássico",
   "general.recordingFeedback.errorSound": "Som de alerta",
+  "general.textProcessing.title": "Preferências de transcrição",
+  "general.textProcessing.description": "Ajuste como o texto transcrito é formatado.",
   "indicator.initializing": "A iniciar...",
   "ui.offlineWarning": "Parece estar offline. Algumas funcionalidades como transferência de modelos podem não funcionar.",
   "general.permissions.title": "Conceder Permissões",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Классические",
   "general.recordingFeedback.errorSound": "Звук оповещения",
+  "general.textProcessing.title": "Настройки транскрипции",
+  "general.textProcessing.description": "Настройте форматирование транскрибированного текста.",
   "indicator.initializing": "Запуск...",
   "ui.offlineWarning": "Похоже, вы не в сети. Некоторые функции, такие как загрузка моделей, могут не работать.",
   "general.permissions.title": "Предоставить Разрешения",

--- a/src/shared/i18n/locales/tr.json
+++ b/src/shared/i18n/locales/tr.json
@@ -378,6 +378,8 @@
   "general.recordingFeedback.sound.error": "Error",
   "general.recordingFeedback.classic": "Klasik",
   "general.recordingFeedback.errorSound": "Uyarı sesi",
+  "general.textProcessing.title": "Transkripsiyon tercihleri",
+  "general.textProcessing.description": "Transkript edilen metnin biçimlendirmesini ayarlayın.",
   "indicator.initializing": "Başlatılıyor...",
   "ui.offlineWarning": "Çevrimdışı görünüyorsunuz. Model indirme gibi bazı özellikler çalışmayabilir.",
   "general.permissions.title": "İzinleri Ver",


### PR DESCRIPTION
## Summary

- Wraps the text processing checkboxes (finish with period, start with lowercase, hold shift to capitalize) in a collapsible card with a "Transcription Preferences" title and description
- Starts collapsed by default, persists open/closed state to localStorage
- Follows the existing button-based collapsible pattern used by HUD and Performance sections
- Adds i18n keys for the section title and description across all 10 locales

## Test plan

- [x] Open General settings panel
- [x] Verify the "Transcription Preferences" section appears collapsed by default
- [x] Click the header to expand — all three checkboxes should be visible
- [x] Click again to collapse — checkboxes hidden, chevron rotates
- [x] Refresh the app — section should remember its open/closed state
- [x] Toggle each checkbox while expanded to confirm they still work

### Screenshot

<img width="702" height="294" alt="image" src="https://github.com/user-attachments/assets/8d1c6da6-3956-4249-a877-e62426450082" />
