### PR TITLE
refactor(ui): replace audio retention select with number input

### DIFF
--- a/src/renderer/components/whisper/WhisperPanel.tsx
+++ b/src/renderer/components/whisper/WhisperPanel.tsx
@@ -7,7 +7,7 @@ import { useDevOverrideValue } from "../../hooks/use-dev-override";
 import { useT } from "../../i18n-context";
 import { ModelSelector } from "../ui/ModelSelector";
 import { TranscriptionTest } from "../ui/TranscriptionTest";
-import { CustomSelect } from "../ui/CustomSelect";
+import { useState } from "react";
 import { OfflineBanner } from "../ui/OfflineBanner";
 import { AlertTriangleIcon } from "../../../shared/icons";
 import card from "../shared/card.module.scss";
@@ -29,6 +29,7 @@ export function WhisperPanel() {
 
   const modelManager = useModelManager();
   const transcriptionTest = useTranscriptionTest(5);
+  const [retentionDraft, setRetentionDraft] = useState<string | null>(null);
 
   if (!config) return null;
 
@@ -83,21 +84,28 @@ export function WhisperPanel() {
           <p className={card.description}>{t("history.audioRetentionDesc")}</p>
         </div>
         <div className={card.body}>
-          <CustomSelect
-            value={String(config.audioRetentionCount ?? 5)}
-            items={[
-              { value: "0", label: t("history.audioRetentionDisabled") },
-              { value: "3", label: "3" },
-              { value: "5", label: "5" },
-              { value: "10", label: "10" },
-              { value: "20", label: "20" },
-            ]}
-            onChange={async (value) => {
-              updateConfig({ audioRetentionCount: Number(value) });
-              await saveConfig(false);
-              triggerToast();
-            }}
-          />
+          <div className={form.field}>
+            <input
+              id="audio-retention-count"
+              type="number"
+              min={0}
+              value={retentionDraft ?? String(config.audioRetentionCount ?? 5)}
+              onChange={(e) => setRetentionDraft(e.target.value)}
+              onBlur={async (e) => {
+                const parsed = Math.max(0, Math.round(Number(e.target.value) || 0));
+                setRetentionDraft(null);
+                updateConfig({ audioRetentionCount: parsed });
+                await saveConfig(false);
+                triggerToast();
+              }}
+              onKeyDown={async (e) => {
+                if (e.key === "Enter") {
+                  (e.target as HTMLInputElement).blur();
+                }
+              }}
+            />
+            <p className={form.hint}>{t("history.audioRetentionHint")}</p>
+          </div>
         </div>
       </div>
     </>

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -254,7 +254,8 @@ html, body, #root {
 
 input[type="url"],
 input[type="password"],
-input[type="text"] {
+input[type="text"],
+input[type="number"] {
   display: block;
   width: 100%;
   padding: 8px 12px;

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Weitere Aktionen",
   "history.audioRetention": "Audio-Aufbewahrung",
   "history.audioRetentionDesc": "Anzahl der zuletzt gespeicherten Audioaufnahmen auf dem Datenträger",
-  "history.audioRetentionDisabled": "Deaktiviert",
+  "history.audioRetentionHint": "Auf 0 setzen, um die Audioaufbewahrung zu deaktivieren",
   "history.cannotRetryWhileRecording": "Erneuter Versuch während laufender Aufnahme nicht möglich",
   "general.recordingFeedback.title": "Aufnahme-Feedback",
   "general.recordingFeedback.description": "Töne beim Starten und Stoppen der Aufnahme abspielen.",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -356,7 +356,7 @@
   "history.moreActions": "More actions",
   "history.audioRetention": "Audio retention",
   "history.audioRetentionDesc": "Number of recent audio recordings to keep on disk",
-  "history.audioRetentionDisabled": "Disabled",
+  "history.audioRetentionHint": "Set to 0 to disable audio retention",
   "history.cannotRetryWhileRecording": "Cannot retry while recording is in progress",
   "general.recordingFeedback.title": "Recording Feedback",
   "general.recordingFeedback.description": "Play sounds when recording starts and stops.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Más acciones",
   "history.audioRetention": "Retención de audio",
   "history.audioRetentionDesc": "Número de grabaciones de audio recientes a conservar en disco",
-  "history.audioRetentionDisabled": "Desactivado",
+  "history.audioRetentionHint": "Establezca en 0 para desactivar la retención de audio",
   "history.cannotRetryWhileRecording": "No se puede reintentar mientras la grabación está en progreso",
   "general.recordingFeedback.title": "Retroalimentación de Grabación",
   "general.recordingFeedback.description": "Reproducir sonidos al iniciar y detener la grabación.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Plus d'actions",
   "history.audioRetention": "Rétention audio",
   "history.audioRetentionDesc": "Nombre d'enregistrements audio récents à conserver sur le disque",
-  "history.audioRetentionDisabled": "Désactivé",
+  "history.audioRetentionHint": "Réglez sur 0 pour désactiver la rétention audio",
   "history.cannotRetryWhileRecording": "Impossible de réessayer pendant un enregistrement en cours",
   "general.recordingFeedback.title": "Retour d'enregistrement",
   "general.recordingFeedback.description": "Jouer des sons au début et à la fin de l'enregistrement.",

--- a/src/shared/i18n/locales/it.json
+++ b/src/shared/i18n/locales/it.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Altre azioni",
   "history.audioRetention": "Conservazione audio",
   "history.audioRetentionDesc": "Numero di registrazioni audio recenti da conservare su disco",
-  "history.audioRetentionDisabled": "Disattivato",
+  "history.audioRetentionHint": "Impostare su 0 per disattivare la conservazione audio",
   "history.cannotRetryWhileRecording": "Impossibile riprovare durante una registrazione in corso",
   "general.recordingFeedback.title": "Feedback di Registrazione",
   "general.recordingFeedback.description": "Riprodurre suoni all'inizio e alla fine della registrazione.",

--- a/src/shared/i18n/locales/pl.json
+++ b/src/shared/i18n/locales/pl.json
@@ -377,7 +377,7 @@
   "history.moreActions": "Więcej akcji",
   "history.audioRetention": "Przechowywanie audio",
   "history.audioRetentionDesc": "Liczba ostatnich nagrań audio do przechowywania na dysku",
-  "history.audioRetentionDisabled": "Wyłączone",
+  "history.audioRetentionHint": "Ustaw na 0, aby wyłączyć przechowywanie nagrań audio",
   "history.cannotRetryWhileRecording": "Nie można ponowić próby podczas trwającego nagrywania",
   "ui.offlineWarning": "Wygląda na to, że jesteś offline. Niektóre funkcje, takie jak pobieranie modeli, mogą nie działać.",
   "general.permissions.title": "Przyznaj Uprawnienia",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Mais ações",
   "history.audioRetention": "Retenção de áudio",
   "history.audioRetentionDesc": "Número de gravações de áudio recentes a manter no disco",
-  "history.audioRetentionDisabled": "Desativado",
+  "history.audioRetentionHint": "Defina como 0 para desativar a retenção de áudio",
   "history.cannotRetryWhileRecording": "Não é possível tentar novamente enquanto a gravação está em andamento",
   "general.recordingFeedback.title": "Feedback de Gravação",
   "general.recordingFeedback.description": "Reproduzir sons ao iniciar e parar a gravação.",

--- a/src/shared/i18n/locales/pt-PT.json
+++ b/src/shared/i18n/locales/pt-PT.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Mais ações",
   "history.audioRetention": "Retenção de áudio",
   "history.audioRetentionDesc": "Número de gravações de áudio recentes a manter no disco",
-  "history.audioRetentionDisabled": "Desativado",
+  "history.audioRetentionHint": "Defina como 0 para desativar a retenção de áudio",
   "history.cannotRetryWhileRecording": "Não é possível tentar novamente enquanto a gravação está em curso",
   "general.recordingFeedback.title": "Feedback de Gravação",
   "general.recordingFeedback.description": "Reproduzir sons ao iniciar e parar a gravação.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Другие действия",
   "history.audioRetention": "Хранение аудио",
   "history.audioRetentionDesc": "Количество последних аудиозаписей для хранения на диске",
-  "history.audioRetentionDisabled": "Отключено",
+  "history.audioRetentionHint": "Установите 0, чтобы отключить хранение аудио",
   "history.cannotRetryWhileRecording": "Невозможно повторить во время записи",
   "general.recordingFeedback.title": "Обратная связь записи",
   "general.recordingFeedback.description": "Воспроизводить звуки при начале и окончании записи.",

--- a/src/shared/i18n/locales/tr.json
+++ b/src/shared/i18n/locales/tr.json
@@ -357,7 +357,7 @@
   "history.moreActions": "Diğer işlemler",
   "history.audioRetention": "Ses saklama",
   "history.audioRetentionDesc": "Diskte saklanacak son ses kaydı sayısı",
-  "history.audioRetentionDisabled": "Devre dışı",
+  "history.audioRetentionHint": "Ses kaydı tutmayı devre dışı bırakmak için 0 olarak ayarlayın",
   "history.cannotRetryWhileRecording": "Kayıt devam ederken yeniden denenemez",
   "general.recordingFeedback.title": "Kayıt Geri Bildirimi",
   "general.recordingFeedback.description": "Kayıt başladığında ve durduğunda ses çal.",


### PR DESCRIPTION
## Summary
- Replace the fixed-option `CustomSelect` dropdown for audio retention with a free-form number input
- Users can now set any value (0 = disabled, any positive integer for retention count)
- Add `input[type="number"]` to global CSS input styles for consistent appearance

## Test plan
- [x] Open Speech settings tab and verify the audio retention field is a number input
- [x] Enter various values (0, 5, 50, 100) and confirm they save correctly
- [x] Verify 0 disables audio retention
- [x] Verify negative values are clamped to 0
- [x] Check the field has correct styling (background, border-radius, focus states)