### PR TITLE
fix(ui): show only action button or status badge in PermissionRow

### DIFF
--- a/src/renderer/components/ui/PermissionRequest.tsx
+++ b/src/renderer/components/ui/PermissionRequest.tsx
@@ -42,28 +42,18 @@ export function PermissionRequest({
           <span className={`${styles.badge} ${styles.granted}`}>
             {t("permissions.granted")}
           </span>
+        ) : buttonText && onRequest ? (
+          <button
+            onClick={onRequest}
+            disabled={requesting}
+            className={`${btn.btn} ${btn.secondary} ${btn.sm}`}
+          >
+            {requesting ? t("permissions.requesting") : buttonText}
+          </button>
         ) : (
-          <>
-            {statusText && (
-              <span className={`${styles.badge} ${styles.missing}`}>
-                {statusText}
-              </span>
-            )}
-            {!statusText && (
-              <span className={`${styles.badge} ${styles.missing}`}>
-                {t("permissions.notGranted")}
-              </span>
-            )}
-            {buttonText && onRequest && (
-              <button
-                onClick={onRequest}
-                disabled={requesting}
-                className={`${btn.btn} ${btn.secondary} ${btn.sm}`}
-              >
-                {requesting ? t("permissions.requesting") : buttonText}
-              </button>
-            )}
-          </>
+          <span className={`${styles.badge} ${styles.missing}`}>
+            {statusText ?? t("permissions.notGranted")}
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- When a permission is not granted and has an action button (e.g. "Grant Access"), show **only** the button instead of both the "Not Granted" badge and the button redundantly
- When no action is available, show only the status badge ("Not Granted" or custom status text)
- Simplifies the ternary logic in `PermissionRequest` component from nested fragments to a clean three-way conditional

## Test plan
- [ ] Verify microphone permission row shows only "Grant Access" button when not granted
- [ ] Verify accessibility permission row shows only "Open Settings" button when not granted
- [ ] Verify keychain row shows only status badge when no action is available
- [ ] Verify all permissions show "Granted" badge when granted
- [ ] Verify onboarding wizard permissions step renders correctly

Preventing this behaviour: 
<img width="665" height="109" alt="image" src="https://github.com/user-attachments/assets/7d88a83e-b5e6-4860-8728-b650456eff9a" />
