### PR TITLE
feat(llm): wrap custom prompt in XML tags for clearer boundary delimitation

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -145,7 +145,7 @@ export function buildSystemPrompt(customPrompt: string, dictionary: string[] = [
     return prompt;
   }
 
-  return `${prompt}\n\n${"*".repeat(70)}\nEXTREMELY IMPORTANT - YOU MUST FOLLOW THESE CUSTOM INSTRUCTIONS\n${"*".repeat(70)}\n\nThe user has provided specific custom instructions below. It is of CRITICAL importance that you consider and apply these instructions. These custom rules take ABSOLUTE PRIORITY over default behavior:\n\n${customPrompt}`;
+  return `${prompt}\n\n${"*".repeat(70)}\nEXTREMELY IMPORTANT - YOU MUST FOLLOW THESE CUSTOM INSTRUCTIONS\n${"*".repeat(70)}\n\nThe user has provided specific custom instructions below. It is of CRITICAL importance that you consider and apply these instructions. These custom rules take ABSOLUTE PRIORITY over default behavior:\n\n<custom-instructions>\n${customPrompt}\n</custom-instructions>`;
 }
 
 export interface WhisperLanguage {

--- a/tests/shared/constants.test.ts
+++ b/tests/shared/constants.test.ts
@@ -93,20 +93,25 @@ describe("buildSystemPrompt", () => {
     const result = buildSystemPrompt("Be formal", ["Kubernetes"]);
     expect(result).toContain("DICTIONARY");
     expect(result).toContain('"Kubernetes"');
-    expect(result).toContain("Be formal");
+    expect(result).toContain("<custom-instructions>\nBe formal\n</custom-instructions>");
   });
 
   it("should place dictionary before custom prompt", () => {
     const result = buildSystemPrompt("Be formal", ["Kubernetes"]);
     const dictIndex = result.indexOf("DICTIONARY");
-    const customIndex = result.indexOf("Be formal");
+    const customIndex = result.indexOf("<custom-instructions>");
     expect(dictIndex).toBeLessThan(customIndex);
+  });
+
+  it("should wrap custom prompt in XML tags", () => {
+    const result = buildSystemPrompt("Always respond in bullet points", []);
+    expect(result).toContain("<custom-instructions>\nAlways respond in bullet points\n</custom-instructions>");
   });
 
   it("should not include dictionary section when array is empty", () => {
     const result = buildSystemPrompt("Be formal", []);
     expect(result).not.toContain("DICTIONARY");
-    expect(result).toContain("Be formal");
+    expect(result).toContain("<custom-instructions>\nBe formal\n</custom-instructions>");
   });
 
   it("should include language context when speechLanguages provided", () => {


### PR DESCRIPTION
## Summary

- Wrap the user's custom prompt in `<custom-instructions>` XML tags within the LLM system prompt
- Provides a clear structural boundary between system-level instructions and user-provided custom instructions, consistent with how `<transcription>` tags are used to delimit transcribed text

## Context

The LLM system prompt already uses XML tags (`<transcription>`) to clearly delimit transcribed speech content. Custom prompts, however, were injected as raw text with only emphasis markers (asterisks). This change adds `<custom-instructions>` XML tags around the custom prompt to provide the same clear boundary, reducing the chance of the LLM confusing custom prompt content with its own instructions.

## Test plan

- [x] Updated existing tests for custom prompt inclusion
- [x] All tests pass
- [x] Typecheck, lint, css-lint, token-check all clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)