### PR TITLE
fix(hud): mark retry as failed when transcription is rejected as garbage

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -380,6 +380,16 @@ export function registerIpcHandlers(
 
     try {
       const text = await retryPipeline.retryFromRecording(recording);
+
+      if (!text.trim()) {
+        historyManager.updateEntry(entryId, {
+          status: "whisper_failed",
+          errorMessage: "No speech detected",
+          failedStep: "garbage",
+        });
+        return historyManager.getEntry(entryId);
+      }
+
       const finalText = applyCase(stripTrailingPeriod(text), config.lowercaseStart);
 
       historyManager.updateEntry(entryId, {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -14,7 +14,7 @@ export interface TranscriptionEntry {
   status: TranscriptionStatus;
   audioFilePath?: string;
   errorMessage?: string;
-  failedStep?: "whisper" | "llm";
+  failedStep?: "whisper" | "llm" | "garbage";
 }
 
 export interface PaginatedResult<T> {


### PR DESCRIPTION
## Summary
- When retrying a transcription that hits a Whisper hallucination loop, all retry attempts fail and the pipeline returns an empty string
- The `history:retry` IPC handler unconditionally marked the entry as `status: "success"` with empty text, resulting in a silent 0-word entry with no error indicator
- Now checks if the retry returns empty text and correctly sets `status: "whisper_failed"` with `failedStep: "garbage"` so the UI shows the error state
- Added `"garbage"` to the `failedStep` union type in `TranscriptionEntry`

## Test plan
- [x] Record audio that triggers Whisper hallucination loop (e.g. background noise)
- [x] Verify the entry shows with error indicator (triangle icon + "Whisper failed" badge)
- [x] Retry the entry from the transcriptions panel
- [x] Verify the entry still shows the error indicator after retry fails (not silent 0 words)
- [x] Verify that a successful retry still updates the entry correctly with transcribed text