### PR TITLE
fix(electron): show Vox icon in dock during dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "electron-vite build",
     "start": "electron-vite preview",
+    "predev": "./scripts/set-dev-icon.sh",
     "dev": "electron-vite dev",
     "build:legacy": "tsc",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",

--- a/scripts/set-dev-icon.sh
+++ b/scripts/set-dev-icon.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Replaces the default Electron icon with the Vox dev icon so the dock/taskbar
+# shows the correct branding during development.
+
+set -euo pipefail
+
+ELECTRON_DIR="node_modules/electron/dist"
+
+case "$(uname -s)" in
+  Darwin)
+    cp build/icon-dev.icns "$ELECTRON_DIR/Electron.app/Contents/Resources/electron.icns"
+    touch "$ELECTRON_DIR/Electron.app"
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$ELECTRON_DIR/Electron.app"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    # electron.exe embeds its icon at build time; rcedit can swap it at dev time
+    if command -v npx &>/dev/null && npx rcedit --help &>/dev/null 2>&1; then
+      npx rcedit "$ELECTRON_DIR/electron.exe" --set-icon build/icon-dev.ico
+    else
+      echo "warning: rcedit not available, skipping dev icon on Windows" >&2
+    fi
+    ;;
+  *)
+    # Linux: no reliable way to change the dock icon at runtime; skip silently
+    ;;
+esac


### PR DESCRIPTION
## Summary
- In dev mode (`npm run dev`), the macOS dock showed the default Electron icon instead of the Vox icon
- Added a cross-platform `predev` script that replaces Electron's embedded icon before launching the dev server
- macOS: copies `icon-dev.icns` over `electron.icns` and invalidates the LaunchServices cache via `lsregister`
- Windows: uses `rcedit` to swap the `.ico` in `electron.exe` (prepared for upcoming Windows support)

## Test plan
- [x] Run `make dev` on macOS and verify the Vox dev icon appears in the dock
- [x] Verify the icon persists (doesn't revert to Electron icon)
- [x] Run `npm install` followed by `make dev` to confirm the predev script runs after dependency reinstall

<img width="331" height="102" alt="image" src="https://github.com/user-attachments/assets/4af35aba-4945-477f-8352-afcfb53731b1" />