### PR TITLE
chore(make): reorganize targets and add cmake dependency check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to Vox! Here's how to get started.
 
 ## Development setup
 
-> **Requires:** [cmake](https://cmake.org/) (`brew install cmake` on macOS) — needed to build the whisper.cpp binary on first install.
+> **Requires:** [cmake](https://cmake.org/download) — needed to build the whisper.cpp binary on first install.
 
 ```bash
 git clone https://github.com/app-vox/vox.git

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 release: build uninstall deploy
 
 install:
-	@which cmake > /dev/null 2>&1 || (echo "cmake is required. Install it with: brew install cmake"; exit 1)
+	@which cmake > /dev/null 2>&1 || (echo "cmake is required. See https://cmake.org/download"; exit 1)
 	npm install
 
 build:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If correction fails, raw transcription is used. If transcription is empty (silen
 
 ### Setup
 
-> Requires [cmake](https://cmake.org/) (`brew install cmake` on macOS).
+> Requires [cmake](https://cmake.org/download).
 
 ```bash
 git clone https://github.com/app-vox/vox.git


### PR DESCRIPTION
## Summary

Reorganizes Makefile targets to clarify intent and adds a cmake dependency check for local development.

## Changes

- Renames `make install` → `make deploy` (copies built `.app` to `/Applications` and opens it)
- Adds new `make install` that runs `npm install` with a pre-check for `cmake` — prints a clear error (`cmake is required. Install it with: brew install cmake`) if not found
- Updates `make dev` and `make run` to depend on `make install` instead of calling `npm install` directly
- Updates `make release` to use `deploy` instead of the old `install`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `make install` with cmake missing shows helpful error message
- [x] `make install` with cmake present runs `npm install` successfully
- [x] `make dev` triggers `make install` before starting dev server
- [x] `make deploy` copies `.app` to `/Applications` as before
- [x] `make release` still works end-to-end

## Code standards

- [x] **i18n** — All user-facing strings use the translation system. New keys added to **all** locale files.
- [x] **Dev Panel** — New internal state is exposed in the Dev Panel where useful for debugging.
- [x] **CSS** — CSS Modules with CSS custom properties. No hardcoded color/spacing values.
- [x] **SVGs** — SVG assets in separate files, not inlined in TSX.
- [x] **Accessibility** — Interactive elements are keyboard-navigable with appropriate ARIA attributes.