### PR TITLE
ci: replace codecov action with direct CLI to fix Node.js 20 warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           curl -Os https://cli.codecov.io/latest/linux/codecov
           chmod +x codecov
-          ./codecov upload-process --fail-on-error=false --file coverage/lcov.info
+          ./codecov upload-process --file coverage/lcov.info || true
 
       - name: Build
         id: build


### PR DESCRIPTION
## Summary

- `codecov/codecov-action@v5.5.2` uses `actions/github-script@v7.0.1` which runs on Node.js 20, causing a deprecation warning
- Replace the GitHub Action with a direct `codecov` CLI call, eliminating the transitive Node.js 20 dependency entirely

## Test plan

- [ ] CI pipeline passes without the Node.js 20 deprecation warning
- [ ] Coverage is still uploaded to Codecov