### PR TITLE
feat(llm): fix GLM (Zhipu AI) support to OpenAI compatible provider

### DIFF
--- a/src/main/llm/factory.ts
+++ b/src/main/llm/factory.ts
@@ -73,6 +73,7 @@ export function createLlmProvider(config: VoxConfig, options?: CreateLlmProvider
         model: config.llm.openaiModel,
         customPrompt: prompt,
         hasCustomPrompt,
+        providerType: config.llm.provider as "openai" | "deepseek" | "glm" | "litellm",
       });
 
     case "custom":

--- a/src/main/llm/openai-compatible.ts
+++ b/src/main/llm/openai-compatible.ts
@@ -7,6 +7,7 @@ export interface OpenAICompatibleConfig {
   model: string;
   customPrompt: string;
   hasCustomPrompt: boolean;
+  providerType?: "openai" | "deepseek" | "glm" | "litellm";
 }
 
 interface ChatCompletionResponse {
@@ -14,18 +15,22 @@ interface ChatCompletionResponse {
 }
 
 export class OpenAICompatibleProvider extends BaseLlmProvider {
-  protected readonly providerName = "OpenAICompatible";
+  protected providerName: string = "OpenAICompatible";
   private readonly config: OpenAICompatibleConfig;
 
   constructor(config: OpenAICompatibleConfig) {
     super(config.customPrompt, config.hasCustomPrompt);
     this.config = config;
+    if (config.providerType) {
+      this.providerName = config.providerType.toUpperCase();
+    }
   }
 
   protected async enhance(rawText: string): Promise<string> {
     const slog = log.scope(this.providerName);
     const base = this.config.endpoint.replace(/\/+$/, "");
-    const url = `${base}/v1/chat/completions`;
+    const path = this.config.providerType === "glm" ? "/chat/completions" : "/v1/chat/completions";
+    const url = `${base}${path}`;
 
     const requestBody = {
       model: this.config.model,


### PR DESCRIPTION
## Summary

Add GLM (Zhipu AI) provider support to the OpenAI compatible provider, enabling users to use GLM models through the OpenAI-compatible interface.

## Changes

- Add `providerType` option to `OpenAICompatibleConfig` interface
- GLM uses `/chat/completions` endpoint instead of `/v1/chat/completions`
- Set provider name dynamically based on provider type for better logging

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Manually tested with GLM API endpoint