### PR TITLE
fix(hud): improve drag smoothness and fix IPC listener leak

### DIFF
--- a/src/main/hud.ts
+++ b/src/main/hud.ts
@@ -698,6 +698,7 @@ interactiveEls.forEach(function(el) {
     window.electronAPI?.setIgnoreMouseEvents(false);
   });
   el.addEventListener('mouseleave', function() {
+    if (isDragging) return;
     if (currentState !== 'idle' && currentState !== 'transcribing' && currentState !== 'enhancing') return;
     ignoreDisabled = false;
     window.electronAPI?.setIgnoreMouseEvents(true);

--- a/src/main/shortcuts/manager.ts
+++ b/src/main/shortcuts/manager.ts
@@ -860,7 +860,7 @@ export class ShortcutManager {
       }
     });
 
-    ipcMain.handle("hud:drag", (_event, dx: number, dy: number) => {
+    ipcMain.on("hud:drag", (_event, dx: number, dy: number) => {
       this.hud.drag(dx, dy);
     });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -106,7 +106,7 @@ export interface VoxAPI {
     add(entry: { text: string; originalText: string; audioDurationMs: number; whisperModel: string; llmEnhanced: boolean }): Promise<void>;
     deleteEntry(id: string): Promise<void>;
     clear(): Promise<void>;
-    onEntryAdded(callback: () => void): void;
+    onEntryAdded(callback: () => void): () => void;
     retry(entryId: string): Promise<import("../shared/types").TranscriptionEntry>;
     downloadAudio(entryId: string): Promise<string>;
     getAudioPath(entryId: string): Promise<string | null>;
@@ -254,7 +254,9 @@ const voxApi: VoxAPI = {
     deleteEntry: (id) => ipcRenderer.invoke("history:delete-entry", id),
     clear: () => ipcRenderer.invoke("history:clear"),
     onEntryAdded: (callback) => {
-      ipcRenderer.on("history:entry-added", () => callback());
+      const handler = () => callback();
+      ipcRenderer.on("history:entry-added", handler);
+      return () => { ipcRenderer.removeListener("history:entry-added", handler); };
     },
     retry: (entryId) => ipcRenderer.invoke("history:retry", entryId),
     downloadAudio: (entryId) => ipcRenderer.invoke("history:download-audio", entryId),
@@ -306,7 +308,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   hudOpenSettings: () => ipcRenderer.invoke("hud:open-settings"),
   hudOpenTranscriptions: () => ipcRenderer.invoke("hud:open-transcriptions"),
   hudDisable: () => ipcRenderer.invoke("hud:disable"),
-  hudDrag: (dx: number, dy: number) => ipcRenderer.invoke("hud:drag", dx, dy),
+  hudDrag: (dx: number, dy: number) => ipcRenderer.send("hud:drag", dx, dy),
   hudDragEnd: () => ipcRenderer.invoke("hud:drag-end"),
   setIgnoreMouseEvents: (ignore: boolean) => ipcRenderer.invoke("hud:set-ignore-mouse", ignore),
   hudCopyLatest: () => ipcRenderer.invoke("hud:copy-latest"),

--- a/src/renderer/components/transcriptions/TranscriptionsPanel.tsx
+++ b/src/renderer/components/transcriptions/TranscriptionsPanel.tsx
@@ -213,7 +213,7 @@ export function TranscriptionsPanel() {
   }, [fetchPage]);
 
   useEffect(() => {
-    window.voxApi.history.onEntryAdded(() => {
+    return window.voxApi.history.onEntryAdded(() => {
       fetchPage();
     });
   }, [fetchPage]);


### PR DESCRIPTION
## Summary

- **HUD drag stutter**: Changed `hud:drag` IPC from `invoke` (round-trip, waits for response) to `send` (fire-and-forget) — eliminates per-frame latency during drag. Also skip `setIgnoreMouseEvents(true)` while actively dragging to prevent Windows from intermittently dropping mouse events mid-drag.
- **MaxListenersExceeded warning**: `onEntryAdded` was adding a new IPC listener on every `fetchPage` dependency change without removing the previous one. Now returns a cleanup function, and the `useEffect` in `TranscriptionsPanel` properly tears it down.

## Test plan

- [ ] Drag HUD widget around the screen — should be smooth without freezing/stuttering
- [ ] Navigate to transcriptions tab multiple times and verify no `MaxListenersExceededWarning` in console
- [ ] Verify HUD click interactions still work after dragging (stop recording, cancel, etc.)