### PR TITLE
fix(windows): prevent scroll freeze and make Makefile cross-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 .PHONY: release run dev build build-dev install deploy uninstall
 
-release: build uninstall deploy
+UNAME := $(shell uname -s)
+
+release: build deploy
 
 install:
 	@which cmake > /dev/null 2>&1 || (echo "cmake is required. See https://cmake.org/download"; exit 1)
 	npm install
 
+ifeq ($(UNAME),Darwin)
 build:
 	npm run dist
 
@@ -21,6 +24,23 @@ deploy:
 
 uninstall:
 	rm -rf /Applications/Vox.app
+else
+build:
+	-cmd //c "taskkill /F /IM Vox.exe /T" 2>/dev/null; sleep 1
+	npm run dist
+
+build-dev:
+	npm run build && npx electron-builder --win dir
+
+deploy:
+	@EXE=$$(find dist -maxdepth 2 -name 'Vox.exe' -type f 2>/dev/null | head -1); \
+	if [ -z "$$EXE" ]; then echo "Vox.exe not found in dist/. Run 'make build' first."; exit 1; fi; \
+	echo "Starting $$EXE"; \
+	"$$EXE" &
+
+uninstall:
+	-cmd //c "taskkill /F /IM Vox.exe /T" 2>/dev/null
+endif
 
 run: install
 	npm run start

--- a/src/renderer/components/layout/Sidebar.module.scss
+++ b/src/renderer/components/layout/Sidebar.module.scss
@@ -99,6 +99,7 @@
   flex: 1;
   overflow-y: auto;
   padding: var(--spacing-1) var(--spacing-2);
+  -webkit-app-region: no-drag;
 
   &::-webkit-scrollbar {
     width: 4px;

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -350,6 +350,7 @@ select {
   flex: 1;
   overflow-y: scroll;
   padding: 24px;
+  -webkit-app-region: no-drag;
 
   &::-webkit-scrollbar {
     width: 6px;


### PR DESCRIPTION
## Summary

- Fix intermittent scroll freeze on Windows caused by `-webkit-app-region: drag` bleeding from titlebar/sidebar into scrollable areas
- Make `Makefile` cross-platform with `ifeq(Darwin)/else` blocks — Windows targets kill running Vox.exe before build, use `--win dir` for dev builds

## Changes

- `src/renderer/globals.css`: add `-webkit-app-region: no-drag` to `.content`
- `src/renderer/components/layout/Sidebar.module.scss`: add `-webkit-app-region: no-drag` to `.nav`
- `Makefile`: platform-conditional `build`, `build-dev`, `deploy`, `uninstall` targets

## Root cause

On Windows with `frame: false`, Chromium can propagate the drag region from the titlebar into adjacent scrollable elements, intermittently capturing mouse events and preventing scroll.

## Test plan

- [ ] Scroll content area on Windows — verify no freezes after hovering titlebar
- [ ] Scroll sidebar nav on Windows — verify smooth scrolling
- [ ] `make build` on Windows — kills Vox.exe, runs dist
- [ ] `make deploy` on Windows — finds and launches Vox.exe
- [ ] `make build` on macOS — runs dist directly (no taskkill)
- [ ] `make deploy` on macOS — copies to /Applications and opens