### PR TITLE
fix(ci): rename Windows NSIS artifacts to match release upload names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,11 +240,17 @@ jobs:
           # Create stable-named copies for releases/latest/download URLs
           DMG=$(find release -name "*.dmg" ! -name "Vox-mac-arm64.dmg" | head -1)
           ZIP=$(find release -name "*-mac.zip" | head -1)
-          EXE=$(find release -name "*.exe" ! -name "Vox-win-x64.exe" | head -1)
+          EXE=$(find release -name "*.exe" ! -name "Vox-win-x64.exe" ! -name "Vox-${VERSION}-x64.exe" | head -1)
+          BLOCKMAP=$(find release -name "*.exe.blockmap" ! -name "Vox-${VERSION}-x64.exe.blockmap" | head -1)
 
           cp "$DMG" "release/Vox-mac-arm64.dmg"
           cp "$ZIP" "release/Vox-mac-arm64.zip"
           cp "$EXE" "release/Vox-win-x64.exe"
+
+          # NSIS produces "Vox Setup X.Y.Z.exe" — create dash-named versioned copies
+          # to match the naming convention used by electron-builder on macOS
+          cp "$EXE" "release/Vox-${VERSION}-x64.exe"
+          cp "$BLOCKMAP" "release/Vox-${VERSION}-x64.exe.blockmap"
 
           ls -lh release/
 


### PR DESCRIPTION
## Summary
- NSIS installer produces `Vox Setup X.Y.Z.exe` (with spaces) but `gh release create` expects `Vox-X.Y.Z-x64.exe` (dashes)
- Adds copy step in "Prepare release assets" to create dash-named versioned copies for both the exe and blockmap
- Fixes the v0.17.0 release failure at the "Create GitHub Release" step

## Test plan
- [ ] Re-run the Release workflow (dry run) and verify all assets are listed in `ls -lh release/`
- [ ] Confirm `gh release create` succeeds with all expected filenames