### PR TITLE
chore(renovate): modernize config syntax and group ecosystem packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,14 @@ All five commands must exit with code 0. Do not commit or claim success if any o
 
 Pipeline tests (`npm run test:pipeline`) are **not** part of the standard validation. They call external LLM APIs (with real cost) and require a separate config file. Never run them automatically — only on explicit user request. See `docs/pipeline-testing.md` for setup.
 
+## Dependencies
+
+When adding or removing a package, cross-check `renovate.json` so Renovate keeps PRs grouped per ecosystem instead of one PR per package:
+
+- If the package fits an existing group (e.g., a build-tool plugin in `Build tools`, a linter in `Linters and formatters`, a type-defs package in `Type definitions`, a new Electron tool in `Electron ecosystem`), no change is needed; the existing rule already covers it.
+- If the package is the first of an ecosystem with several related siblings, add a `packageRules` entry with a `groupName`.
+- Anything that calls `node-gyp` or loads a `.node` binary (current set: `whisper-node`, `koffi`, `uiohook-napi`) goes in the `Native modules` rule with `automerge: false` and the `prBodyNotes` test checklist, since it has to be re-tested on both architectures.
+
 ## Issue Tracking
 
 Bugs, feature requests, and technical work are tracked as GitHub Issues in **this repo**. When creating issues, always add them to the organization's public project board (the one linked to `app-vox/vox`).

--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "mode": "full",
   "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits",
-    ":separateMajorReleases"
+    "config:best-practices",
+    ":automergeStableNonMajor",
+    ":automergePatch",
+    ":automergeDigest",
+    ":timezone(Europe/Berlin)",
+    "mergeConfidence:all-badges"
   ],
   "labels": ["dependencies"],
   "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
+  "schedule": ["before 9am on monday"],
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["dependencies", "security", "priority:high"],
@@ -19,15 +21,7 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "Automerge patch updates for all packages",
-      "matchUpdateTypes": ["patch", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "platformAutomerge": true
-    },
-    {
-      "description": "Automerge minor updates for devDependencies",
+      "description": "Automerge minor updates for devDependencies (covers 0.x where :automergeStableNonMajor opts out)",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor"],
       "automerge": true,
@@ -36,7 +30,7 @@
       "platformAutomerge": true
     },
     {
-      "description": "Group Electron ecosystem packages",
+      "description": "Electron ecosystem — manual review, longer cool-off",
       "groupName": "Electron ecosystem",
       "matchPackageNames": ["electron", "electron-builder", "electron-vite"],
       "minimumReleaseAge": "7 days",
@@ -44,42 +38,58 @@
       "labels": ["dependencies", "electron", "needs-testing"]
     },
     {
-      "description": "Group AWS SDK packages",
       "groupName": "AWS SDK",
-      "matchPackagePatterns": ["^@aws-sdk/"]
+      "matchPackageNames": ["@aws-sdk/{/,}**"]
     },
     {
-      "description": "Group React packages",
       "groupName": "React",
-      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
     },
     {
-      "description": "Group build tools",
       "groupName": "Build tools",
       "matchPackageNames": [
         "vite",
         "vitest",
         "typescript",
         "sass",
-        "tailwindcss"
-      ],
-      "matchPackagePatterns": ["^@vitejs/", "^@tailwindcss/"]
+        "tailwindcss",
+        "@vitejs/{/,}**",
+        "@vitest/{/,}**",
+        "@tailwindcss/{/,}**"
+      ]
     },
     {
-      "description": "Group linters and formatters with automerge",
+      "description": "Linters and formatters — automerge",
       "groupName": "Linters and formatters",
-      "matchPackagePatterns": ["^eslint", "^prettier", "^stylelint"],
-      "matchPackageNames": ["typescript-eslint"],
+      "matchPackageNames": [
+        "typescript-eslint",
+        "/^eslint/",
+        "/^@eslint\\//",
+        "/^prettier/",
+        "/^stylelint/"
+      ],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "platformAutomerge": true
     },
     {
-      "description": "Automerge type definitions (excluding React types handled by React group)",
+      "groupName": "@testing-library",
+      "matchPackageNames": ["@testing-library/{/,}**"]
+    },
+    {
+      "description": "Type definitions — automerge (React types handled separately by React group)",
       "groupName": "Type definitions",
-      "matchPackagePatterns": ["^@types/"],
-      "excludePackageNames": ["@types/react", "@types/react-dom"],
+      "matchPackageNames": [
+        "@types/{/,}**",
+        "!@types/react",
+        "!@types/react-dom"
+      ],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
@@ -101,6 +111,12 @@
         "- [ ] Verify shortcuts work",
         "- [ ] Check DMG build succeeds"
       ]
+    },
+    {
+      "description": "Pin Node/npm engine bumps — they touch CI and the preinstall guard",
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node", "npm"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Objective
Modernize the Renovate config and unify the grouping and automerge tier across ecosystems.

## Context
The previous config still relied on the deprecated `matchPackagePatterns` and `excludePackageNames` fields, and its automerge rules were ad-hoc rather than mapped to the standard Renovate presets.

## Approach
Switch the base preset to `config:best-practices` plus the compact `:automergeStableNonMajor`, `:automergePatch`, and `:automergeDigest` extends. Migrate every rule to the modern `matchPackageNames` glob/regex syntax. Keep the existing Electron, native-module, and vulnerability-alert safeguards. Engine bumps for Node and npm stay manual since they touch the preinstall guard.